### PR TITLE
Fix for: 'count' cannot be computed

### DIFF
--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -29,7 +29,6 @@ module "aurora" {
   replica_scale_min               = 1
   replica_scale_max               = 5
   monitoring_interval             = 60
-  allowed_security_groups         = ["${aws_security_group.app_servers.id}"]
   instance_type                   = "db.r4.large"
   apply_immediately               = true
   skip_final_snapshot             = true

--- a/examples/mysql/main.tf
+++ b/examples/mysql/main.tf
@@ -25,7 +25,6 @@ module "aurora" {
   availability_zones              = ["${var.azs}"]
   vpc_id                          = "${module.vpc.vpc_id}"
   replica_count                   = 1
-  allowed_security_groups         = ["${aws_security_group.app_servers.id}"]
   instance_type                   = "db.t2.medium"
   apply_immediately               = true
   skip_final_snapshot             = true

--- a/examples/postgresql/main.tf
+++ b/examples/postgresql/main.tf
@@ -25,7 +25,6 @@ module "aurora" {
   availability_zones              = ["${var.azs}"]
   vpc_id                          = "${module.vpc.vpc_id}"
   replica_count                   = 1
-  allowed_security_groups         = ["${aws_security_group.app_servers.id}"]
   instance_type                   = "db.r4.large"
   apply_immediately               = true
   skip_final_snapshot             = true


### PR DESCRIPTION
This will make the examples run without this error:

```
* module.aurora.aws_security_group_rule.default_ingress: aws_security_group_rule.default_ingress: value of 'count' cannot be computed
```

It's a terraform problem, not a problem with this module. And it's not 100% required since we have `resource.aws_security_group_rule.allow_access` in the example anyway.