### PR TITLE
Conditional creation of cluster and related resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | auto_minor_version_upgrade | Determines whether minor engine upgrades will be performed automatically in the maintenance window | string | `true` | no |
 | availability_zones | Availability zones for the cluster. Must 3 or less | string | `<list>` | no |
 | backup_retention_period | How long to keep backups for (in days) | string | `7` | no |
+| create_resources | Whether to create the Aurora cluster and related resources | string | `true` | no |
 | db_cluster_parameter_group_name | The name of a DB Cluster parameter group to use | string | `default.aurora5.6` | no |
 | db_parameter_group_name | The name of a DB parameter group to use | string | `default.aurora5.6` | no |
 | engine | Aurora database engine type, currently aurora, aurora-mysql or aurora-postgresql | string | `aurora` | no |

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,7 @@ resource "aws_db_subnet_group" "this" {
 }
 
 resource "aws_rds_cluster" "this" {
+  count                           = "${var.create_cluster}"
   cluster_identifier              = "${var.name}"
   availability_zones              = ["${var.availability_zones}"]
   engine                          = "${var.engine}"
@@ -41,8 +42,7 @@ resource "aws_rds_cluster" "this" {
 }
 
 resource "aws_rds_cluster_instance" "this" {
-  count = "${var.replica_scale_enabled ? var.replica_scale_min : var.replica_count}"
-
+  count                           = "${var.create_cluster ? var.replica_scale_enabled ? var.replica_scale_min : var.replica_count : 0}"
   identifier                      = "${var.name}-${count.index + 1}"
   cluster_identifier              = "${aws_rds_cluster.this.id}"
   engine                          = "${var.engine}"

--- a/main.tf
+++ b/main.tf
@@ -87,14 +87,14 @@ data "aws_iam_policy_document" "monitoring_rds_assume_role" {
 }
 
 resource "aws_iam_role" "rds_enhanced_monitoring" {
-  count = "${var.create_resources ? var.monitoring_interval > 0 ? 1 : 0 : 0}"
+  count = "${var.create_resources && var.monitoring_interval > 0 ? 1 : 0}"
 
   name               = "rds-enhanced-monitoring-${var.name}"
   assume_role_policy = "${data.aws_iam_policy_document.monitoring_rds_assume_role.json}"
 }
 
 resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
-  count = "${var.create_resources ? var.monitoring_interval > 0 ? 1 : 0 : 0}"
+  count = "${var.create_resources && var.monitoring_interval > 0 ? 1 : 0}"
 
   role       = "${aws_iam_role.rds_enhanced_monitoring.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,8 @@ resource "random_id" "master_password" {
 }
 
 resource "aws_db_subnet_group" "this" {
-  count       = "${var.create_resources}"
+  count = "${var.create_resources}"
+
   name        = "${var.name}"
   description = "For Aurora cluster ${var.name}"
   subnet_ids  = ["${var.subnets}"]
@@ -18,7 +19,8 @@ resource "aws_db_subnet_group" "this" {
 }
 
 resource "aws_rds_cluster" "this" {
-  count                           = "${var.create_resources}"
+  count = "${var.create_resources}"
+
   cluster_identifier              = "${var.name}"
   availability_zones              = ["${var.availability_zones}"]
   engine                          = "${var.engine}"
@@ -43,7 +45,8 @@ resource "aws_rds_cluster" "this" {
 }
 
 resource "aws_rds_cluster_instance" "this" {
-  count                           = "${var.create_resources ? var.replica_scale_enabled ? var.replica_scale_min : var.replica_count : 0}"
+  count = "${var.create_resources ? var.replica_scale_enabled ? var.replica_scale_min : var.replica_count : 0}"
+
   identifier                      = "${var.name}-${count.index + 1}"
   cluster_identifier              = "${aws_rds_cluster.this.id}"
   engine                          = "${var.engine}"
@@ -84,13 +87,15 @@ data "aws_iam_policy_document" "monitoring_rds_assume_role" {
 }
 
 resource "aws_iam_role" "rds_enhanced_monitoring" {
-  count              = "${var.create_resources ? var.monitoring_interval > 0 ? 1 : 0 : 0}"
+  count = "${var.create_resources ? var.monitoring_interval > 0 ? 1 : 0 : 0}"
+
   name               = "rds-enhanced-monitoring-${var.name}"
   assume_role_policy = "${data.aws_iam_policy_document.monitoring_rds_assume_role.json}"
 }
 
 resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
-  count      = "${var.create_resources ? var.monitoring_interval > 0 ? 1 : 0 : 0}"
+  count = "${var.create_resources ? var.monitoring_interval > 0 ? 1 : 0 : 0}"
+
   role       = "${aws_iam_role.rds_enhanced_monitoring.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
 }
@@ -128,7 +133,8 @@ resource "aws_appautoscaling_policy" "autoscaling_read_replica_count" {
 }
 
 resource "aws_security_group" "this" {
-  count       = "${var.create_resources}"
+  count = "${var.create_resources}"
+
   name        = "aurora-${var.name}"
   description = "For Aurora cluster ${var.name}"
   vpc_id      = "${var.vpc_id}"
@@ -137,7 +143,8 @@ resource "aws_security_group" "this" {
 }
 
 resource "aws_security_group_rule" "default_ingress" {
-  count                    = "${var.create_resources ? length(var.allowed_security_groups) : 0}"
+  count = "${var.create_resources ? length(var.allowed_security_groups) : 0}"
+
   type                     = "ingress"
   from_port                = "${aws_rds_cluster.this.port}"
   to_port                  = "${aws_rds_cluster.this.port}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,42 +1,39 @@
-// aws_rds_cluster
 output "this_rds_cluster_id" {
   description = "The ID of the cluster"
-  value       = "${aws_rds_cluster.this.id}"
+  value       = "${element(split(",", join(",", aws_rds_cluster.this.*.id)), 0)}"
 }
 
 output "this_rds_cluster_endpoint" {
   description = "The cluster endpoint"
-  value       = "${aws_rds_cluster.this.endpoint}"
+  value       = "${element(split(",", join(",", aws_rds_cluster.this.*.endpoint)), 0)}"
 }
 
 output "this_rds_cluster_reader_endpoint" {
   description = "The cluster reader endpoint"
-  value       = "${aws_rds_cluster.this.reader_endpoint}"
-}
-
-output "this_rds_cluster_master_password" {
-  description = "The master password"
-  value       = "${aws_rds_cluster.this.master_password}"
-}
-
-output "this_rds_cluster_port" {
-  description = "The port"
-  value       = "${aws_rds_cluster.this.port}"
+  value       = "${element(split(",", join(",", aws_rds_cluster.this.*.reader_endpoint)), 0)}"
 }
 
 output "this_rds_cluster_master_username" {
   description = "The master username"
-  value       = "${aws_rds_cluster.this.master_username}"
+  value       = "${element(split(",", join(",", aws_rds_cluster.this.*.master_username)), 0)}"
 }
 
-// aws_rds_cluster_instance
+output "this_rds_cluster_master_password" {
+  description = "The master password"
+  value       = "${element(split(",", join(",", aws_rds_cluster.this.*.master_password)), 0)}"
+}
+
+output "this_rds_cluster_port" {
+  description = "The port"
+  value       = "${element(split(",", join(",", aws_rds_cluster.this.*.port)), 0)}"
+}
+
 output "this_rds_cluster_instance_endpoints" {
   description = "A list of all cluster instance endpoints"
   value       = ["${aws_rds_cluster_instance.this.*.endpoint}"]
 }
 
-// aws_security_group
 output "this_security_group_id" {
   description = "The security group ID of the cluster"
-  value       = "${aws_security_group.this.id}"
+  value       = "${element(split(",", join(",", aws_security_group.this.*.id)), 0)}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -2,8 +2,8 @@ variable "name" {
   description = "Name given resources"
 }
 
-variable "create_cluster" {
-  description = "Whether to create the Aurora cluster"
+variable "create_resources" {
+  description = "Whether to create the Aurora cluster and related resources"
   default     = true
   type        = "string"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,12 @@ variable "name" {
   description = "Name given resources"
 }
 
+variable "create_cluster" {
+  description = "Whether to create the Aurora cluster"
+  default     = true
+  type        = "string"
+}
+
 variable "subnets" {
   description = "List of subnet IDs to use"
   type        = "list"


### PR DESCRIPTION
Adding `create_resources` to allow declaring the module without creating any resources. This is mentioned in https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/2