### PR TITLE
add support for database_name argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | storage_encrypted | Specifies whether the underlying storage layer should be encrypted | string | `true` | no |
 | subnets | List of subnet IDs to use | list | - | yes |
 | tags | A map of tags to add to all resources. | map | `<map>` | no |
+| database_name | Default DB name | string | `` | no |
 | username | Master DB username | string | `root` | no |
 | vpc_id | VPC ID | string | - | yes |
 
@@ -108,6 +109,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | this_rds_cluster_instance_endpoints | aws_rds_cluster_instance |
 | this_rds_cluster_master_password | The master password |
 | this_rds_cluster_master_username | The master username |
+| this_rds_cluster_database_name | The default database name |
 | this_rds_cluster_port | The port |
 | this_rds_cluster_reader_endpoint | The cluster reader endpoint |
 | this_security_group_id | aws_security_group |

--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,7 @@ resource "aws_rds_cluster" "this" {
   engine                          = "${var.engine}"
   engine_version                  = "${var.engine_version}"
   kms_key_id                      = "${var.kms_key_id}"
+  database_name                   = "${var.database_name}"
   master_username                 = "${var.username}"
   master_password                 = "${local.master_password}"
   final_snapshot_identifier       = "${var.final_snapshot_identifier_prefix}-${var.name}-${random_id.snapshot_identifier.hex}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,6 +14,11 @@ output "this_rds_cluster_reader_endpoint" {
   value       = "${aws_rds_cluster.this.reader_endpoint}"
 }
 
+output "this_rds_cluster_database_name" {
+  description = "The name of the default database"
+  value       = "${aws_rds_cluster.this.database_name}"
+}
+
 output "this_rds_cluster_master_password" {
   description = "The master password"
   value       = "${aws_rds_cluster.this.master_password}"

--- a/variables.tf
+++ b/variables.tf
@@ -40,6 +40,11 @@ variable "publicly_accessible" {
   default     = "false"
 }
 
+variable "database_name" {
+  description = "Default DB Name"
+  default     = ""
+}
+
 variable "username" {
   description = "Master DB username"
   default     = "root"


### PR DESCRIPTION
This adds support for the `database_name` argument on `aws_rds_cluster` resources.  

When a new cluster is provisioned there isn't a way to change the default database name.  For example, for a PostgreSQL cluster, the default database will be named `postgres` and the owner will be whatever was set by the `username` module variable.  This PR will allow a user to supply a `database_name` argument to be passed to the `aws-rds-cluster` resource.  The `database_name` argument is not required, and if not supplied, the module will fall back to its current behavior and use the default names.