### PR TITLE
3 adjustments to security group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -129,11 +129,10 @@ resource "aws_appautoscaling_policy" "autoscaling_read_replica_count" {
 }
 
 resource "aws_security_group" "this" {
-  name        = "aurora-${var.name}"
-  description = "For Aurora cluster ${var.name}"
+  name_prefix = "${var.name}-"
   vpc_id      = "${var.vpc_id}"
 
-  tags = "${merge(var.tags, map("Name", "aurora-${var.name}"))}"
+  tags = "${var.tags}"
 }
 
 resource "aws_security_group_rule" "default_ingress" {


### PR DESCRIPTION
- No description attr on aws_security_group to avoid forcing new instance on changes
- Use name-prefix to ensure unique names
- For readability: unnecessary name-prefixes