### PR TITLE
Hardcode number of allowed_security_groups

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,7 @@ resource "aws_security_group" "this" {
 }
 
 resource "aws_security_group_rule" "default_ingress" {
-  count = "${length(var.allowed_security_groups)}"
+  count = "${var.allowed_security_groups_count}"
 
   type                     = "ingress"
   from_port                = "${aws_rds_cluster.this.port}"

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,11 @@ variable "allowed_security_groups" {
   default     = []
 }
 
+variable "allowed_security_groups_count" {
+  description = "The number of Security Groups being added, terraform doesn't let us use length() in a count field"
+  default     = 0
+}
+
 variable "vpc_id" {
   description = "VPC ID"
 }


### PR DESCRIPTION
Unfortunately Terraform doesn't yet handle this well, we have to hardcode
to be able to pass the list correctly.

Encountered in Terraform 0.11.11

Resolves #11