### PR TITLE
Feature/rds cluster resource id output

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | this\_rds\_cluster\_database\_name | Name for an automatically created database on cluster creation |
 | this\_rds\_cluster\_endpoint | The cluster endpoint |
 | this\_rds\_cluster\_id | The ID of the cluster |
+| this\_rds\_cluster\_resource\_id | The Resource ID of the cluster |
 | this\_rds\_cluster\_instance\_endpoints | A list of all cluster instance endpoints |
 | this\_rds\_cluster\_master\_password | The master password |
 | this\_rds\_cluster\_master\_username | The master username |

--- a/examples/mysql/main.tf
+++ b/examples/mysql/main.tf
@@ -79,3 +79,24 @@ module "vpc" {
     "10.0.9.0/25",
   ]
 }
+
+# IAM Policy for use with iam_database_authentication = true
+resource "aws_iam_policy" "aurora_mysql_policy_iam_auth" {
+  name = "test-aurora-db-57-policy-iam-auth"
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "rds-db:connect"
+      ],
+      "Resource": [
+        "arn:aws:rds-db:us-east-1:123456789012:dbuser:${module.aurora.this_rds_cluster_resource_id}/jane_doe"
+      ]
+    }
+  ]
+}
+POLICY
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,6 +4,11 @@ output "this_rds_cluster_id" {
   value       = "${aws_rds_cluster.this.id}"
 }
 
+output "this_rds_cluster_resource_id" {
+  description = "The Resource ID of the cluster"
+  value       = "${aws_rds_cluster.this.cluster_resource_id}"
+}
+
 output "this_rds_cluster_endpoint" {
   description = "The cluster endpoint"
   value       = "${aws_rds_cluster.this.endpoint}"


### PR DESCRIPTION
Fix for issue #27 

I also needed this for my AWS setup. So I've forked this and made the modifications to get it working in my staging environment.

Test it by following these guidelines by Amazon:

[Creating and Using an IAM Policy for IAM Database Access](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.IAMPolicy.html)

Sample policy is in the example file.