### PR TITLE
Feature/rds add engine_mode and global_cluster_identifier

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,8 +17,10 @@ resource "aws_db_subnet_group" "this" {
 }
 
 resource "aws_rds_cluster" "this" {
+  global_cluster_identifier           = "${var.global_cluster_identifier}"
   cluster_identifier                  = "${var.name}"
   engine                              = "${var.engine}"
+  engine_mode                         = "${var.engine_mode}"
   engine_version                      = "${var.engine_version}"
   kms_key_id                          = "${var.kms_key_id}"
   database_name                       = "${var.database_name}"

--- a/variables.tf
+++ b/variables.tf
@@ -205,3 +205,15 @@ variable "enabled_cloudwatch_logs_exports" {
   type        = "list"
   default     = []
 }
+
+variable "global_cluster_identifier" {
+  description = "The global cluster identifier specified on aws_rds_global_cluster"
+  type        = "string"
+  default     = ""
+}
+
+variable "engine_mode" {
+  description = "The database engine mode. Valid values: global, parallelquery, provisioned, serverless."
+  type        = "string"
+  default     = "provisioned"
+}


### PR DESCRIPTION
Needed this for an aurora global database setup that I'm working on.