### PR TITLE
Allow the addition of IP-based ingress rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ module "db" {
 
   replica_count                   = 1
   allowed_security_groups         = ["sg-12345678"]
-  alllowed_security_groups_count  = 1
+  allowed_security_groups_count   = 1
   allowed_cidr_blocks             = ["10.0.0.0/8"]
-  alllowed_cidr_blocks_count      = 1
+  allowed_cidr_blocks_count       = 1
   instance_type                   = "db.r4.large"
   storage_encrypted               = true
   apply_immediately               = true

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ module "db" {
 
   replica_count                   = 1
   allowed_security_groups         = ["sg-12345678"]
-  allowed_security_groups_count   = 1
+  allowed_cidr_blocks             = ["10.0.0.0/8"]
   instance_type                   = "db.r4.large"
   storage_encrypted               = true
   apply_immediately               = true
@@ -65,7 +65,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | allowed\_security\_groups | A list of Security Group ID's to allow access to. | list | `[]` | no |
-| allowed\_security\_groups\_count | The number of Security Groups being added, terraform doesn't let us use length() in a count field | string | `"0"` | no |
+| allowed\_cidr\_blocks | A list of CIDR blocks to allow access to | list | `[]` | no |
 | apply\_immediately | Determines whether or not any DB modifications are applied immediately, or during the maintenance window | string | `"false"` | no |
 | auto\_minor\_version\_upgrade | Determines whether minor engine upgrades will be performed automatically in the maintenance window | string | `"true"` | no |
 | backup\_retention\_period | How long to keep backups for (in days) | string | `"7"` | no |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ module "db" {
 
   replica_count                   = 1
   allowed_security_groups         = ["sg-12345678"]
+  alllowed_security_groups_count  = 1
   allowed_cidr_blocks             = ["10.0.0.0/8"]
+  alllowed_cidr_blocks_count      = 1
   instance_type                   = "db.r4.large"
   storage_encrypted               = true
   apply_immediately               = true
@@ -65,7 +67,9 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | allowed\_security\_groups | A list of Security Group ID's to allow access to. | list | `[]` | no |
+| allowed\_security\_groups\_count | The number of Security Groups being added, terraform doesn't let us use length() in a count field | string | `"0"` | no |
 | allowed\_cidr\_blocks | A list of CIDR blocks to allow access to | list | `[]` | no |
+| allowed\_cidr\_blocks\_count | The number of CIDR blocks being added, terraform doesn't let us use length() in a count field | string | `"0"` | no |
 | apply\_immediately | Determines whether or not any DB modifications are applied immediately, or during the maintenance window | string | `"false"` | no |
 | auto\_minor\_version\_upgrade | Determines whether minor engine upgrades will be performed automatically in the maintenance window | string | `"true"` | no |
 | backup\_retention\_period | How long to keep backups for (in days) | string | `"7"` | no |

--- a/main.tf
+++ b/main.tf
@@ -141,8 +141,13 @@ resource "aws_security_group" "this" {
   tags = "${var.tags}"
 }
 
+locals {
+  allowed_security_groups_count = "${length(var.allowed_security_groups)}"
+  allowed_cidr_blocks_count     = "${length(var.allowed_cidr_blocks)}"
+}
+
 resource "aws_security_group_rule" "default_ingress" {
-  count = "${var.allowed_security_groups_count}"
+  count = "${local.allowed_security_groups_count}"
 
   type                     = "ingress"
   from_port                = "${aws_rds_cluster.this.port}"
@@ -150,4 +155,15 @@ resource "aws_security_group_rule" "default_ingress" {
   protocol                 = "tcp"
   source_security_group_id = "${element(var.allowed_security_groups, count.index)}"
   security_group_id        = "${aws_security_group.this.id}"
+}
+
+resource "aws_security_group_rule" "cidr_ingress" {
+  count = "${local.allowed_cidr_blocks_count}"
+
+  type              = "ingress"
+  from_port         = "${aws_rds_cluster.this.port}"
+  to_port           = "${aws_rds_cluster.this.port}"
+  protocol          = "tcp"
+  cidr_blocks       = "${element(var.allowed_cidr_blocks, count.index)}"
+  security_group_id = "${aws_security_group.this.id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -141,13 +141,8 @@ resource "aws_security_group" "this" {
   tags = "${var.tags}"
 }
 
-locals {
-  allowed_security_groups_count = "${length(var.allowed_security_groups)}"
-  allowed_cidr_blocks_count     = "${length(var.allowed_cidr_blocks)}"
-}
-
 resource "aws_security_group_rule" "default_ingress" {
-  count = "${local.allowed_security_groups_count}"
+  count = "${var.allowed_security_groups_count}"
 
   type                     = "ingress"
   from_port                = "${aws_rds_cluster.this.port}"
@@ -158,7 +153,7 @@ resource "aws_security_group_rule" "default_ingress" {
 }
 
 resource "aws_security_group_rule" "cidr_ingress" {
-  count = "${local.allowed_cidr_blocks_count}"
+  count = "${var.allowed_cidr_blocks_count}"
 
   type              = "ingress"
   from_port         = "${aws_rds_cluster.this.port}"

--- a/main.tf
+++ b/main.tf
@@ -164,6 +164,6 @@ resource "aws_security_group_rule" "cidr_ingress" {
   from_port         = "${aws_rds_cluster.this.port}"
   to_port           = "${aws_rds_cluster.this.port}"
   protocol          = "tcp"
-  cidr_blocks       = "${element(var.allowed_cidr_blocks, count.index)}"
+  cidr_blocks       = [ "${element(var.allowed_cidr_blocks, count.index)}" ]
   security_group_id = "${aws_security_group.this.id}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -17,9 +17,10 @@ variable "allowed_security_groups" {
   default     = []
 }
 
-variable "allowed_security_groups_count" {
-  description = "The number of Security Groups being added, terraform doesn't let us use length() in a count field"
-  default     = 0
+variable "allowed_cidr_blocks" {
+  description = "A list of CIDR blocks which are allowed to access the database"
+  type        = "list"
+  default     = []
 }
 
 variable "vpc_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -17,10 +17,20 @@ variable "allowed_security_groups" {
   default     = []
 }
 
+variable "allowed_security_groups_count" {
+  description = "The number of Security Groups being added, terraform doesn't let us use length() in a count field"
+  default     = 0
+}
+
 variable "allowed_cidr_blocks" {
   description = "A list of CIDR blocks which are allowed to access the database"
   type        = "list"
   default     = []
+}
+
+variable "allowed_cidr_blocks_count" {
+  description = "The number of CIDR blocks being added, terraform doesn't let us use length() in a count field"
+  default     = 0
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
As a user of this module, I would like to be able to whitelist IP address ranges that are allowed to reach my RDS cluster.

I can add ingress rules and reference the output as the target security group, but I can also submit this pull request.

Also, there's no need for the allowed_security_groups_count variable.  Just set a local variable and refer to that for counts.

It's worthy to note that I have already used my fork of this module and it does what I want.