### PR TITLE
vpc_security_group_ids for Terraform 0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | tags | A map of tags to add to all resources. | map | `{}` | no |
 | username | Master DB username | string | `"root"` | no |
 | vpc\_id | VPC ID | string | n/a | yes |
+| vpc\_security\_group\_ids | List of VPC security groups to associate to the cluster in addition to the SG we create in this module | list | `<list>` | no |
 
 ## Outputs
 

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -60,10 +60,11 @@ resource "aws_security_group_rule" "allow_access" {
 }
 
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
-  name   = "example"
-  cidr   = "10.0.0.0/16"
-  azs    = ["${var.azs}"]
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> v1.0"
+  name    = "example"
+  cidr    = "10.0.0.0/16"
+  azs     = ["${var.azs}"]
 
   private_subnets = [
     "10.0.1.0/24",

--- a/examples/mysql/main.tf
+++ b/examples/mysql/main.tf
@@ -56,10 +56,11 @@ resource "aws_security_group_rule" "allow_access" {
 }
 
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
-  name   = "example"
-  cidr   = "10.0.0.0/16"
-  azs    = ["${var.azs}"]
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> v1.0"
+  name    = "example"
+  cidr    = "10.0.0.0/16"
+  azs     = ["${var.azs}"]
 
   private_subnets = [
     "10.0.1.0/24",

--- a/examples/postgresql/main.tf
+++ b/examples/postgresql/main.tf
@@ -56,10 +56,11 @@ resource "aws_security_group_rule" "allow_access" {
 }
 
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
-  name   = "example"
-  cidr   = "10.0.0.0/16"
-  azs    = ["${var.azs}"]
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> v1.0"
+  name    = "example"
+  cidr    = "10.0.0.0/16"
+  azs     = ["${var.azs}"]
 
   private_subnets = [
     "10.0.1.0/24",

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "aws_rds_cluster" "this" {
   preferred_maintenance_window        = "${var.preferred_maintenance_window}"
   port                                = "${local.port}"
   db_subnet_group_name                = "${aws_db_subnet_group.this.name}"
-  vpc_security_group_ids              = ["${aws_security_group.this.id}"]
+  vpc_security_group_ids              = ["${concat(list(aws_security_group.this.id), var.vpc_security_group_ids)}"]
   snapshot_identifier                 = "${var.snapshot_identifier}"
   storage_encrypted                   = "${var.storage_encrypted}"
   apply_immediately                   = "${var.apply_immediately}"

--- a/variables.tf
+++ b/variables.tf
@@ -201,3 +201,9 @@ variable "engine_mode" {
   description = "The database engine mode. Valid values: global, parallelquery, provisioned, serverless."
   default     = "provisioned"
 }
+
+variable "vpc_security_group_ids" {
+  description = "List of VPC security groups to associate to the cluster in addition to the SG we create in this module"
+  type        = "list"
+  default     = []
+}


### PR DESCRIPTION
# Description

Similar to the module [terraform-aws-rds](https://github.com/terraform-aws-modules/terraform-aws-rds), we should support specifying the variable `vpc_security_group_ids` in case user wish to assign previously created security group on the Aurora cluster. Hopefully this will make the 2 modules more consistent since they tackle the same area of AWS services

I first open this for Terraform 0.11 and if everything is OK I will open a new one for Terraform 0.12 afterward
