### PR TITLE
feat(cluster): ability to deploy a cross region Aurora Cluster Read Replica

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "random_id" "master_password" {
 resource "aws_db_subnet_group" "this" {
   name        = "${var.name}"
   description = "For Aurora cluster ${var.name}"
-  subnet_ids  = ["${var.subnets}"]
+  subnet_ids  = "${var.subnets}"
 
   tags = "${merge(var.tags, map("Name", "aurora-${var.name}"))}"
 }

--- a/main.tf
+++ b/main.tf
@@ -100,7 +100,7 @@ resource "aws_iam_role" "rds_enhanced_monitoring" {
 resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
   count = "${var.monitoring_interval > 0 ? 1 : 0}"
 
-  role       = "${aws_iam_role.rds_enhanced_monitoring.name}"
+  role       = "${aws_iam_role.rds_enhanced_monitoring.0.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ resource "aws_rds_cluster" "this" {
   preferred_maintenance_window        = "${var.preferred_maintenance_window}"
   port                                = "${local.port}"
   db_subnet_group_name                = "${aws_db_subnet_group.this.name}"
-  vpc_security_group_ids              = ["${concat(list(aws_security_group.this.id), var.vpc_security_group_ids)}"]
+  vpc_security_group_ids              = concat([aws_security_group.this.id], var.vpc_security_group_ids)
   snapshot_identifier                 = "${var.snapshot_identifier}"
   storage_encrypted                   = "${var.storage_encrypted}"
   apply_immediately                   = "${var.apply_immediately}"

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,8 @@ resource "aws_db_subnet_group" "this" {
 resource "aws_rds_cluster" "this" {
   global_cluster_identifier           = "${var.global_cluster_identifier}"
   cluster_identifier                  = "${var.name}"
+  replication_source_identifier       = "${var.replication_source_identifier}"
+  source_region                       = "${var.source_region}"
   engine                              = "${var.engine}"
   engine_mode                         = "${var.engine_mode}"
   engine_version                      = "${var.engine_version}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,6 +4,11 @@ output "this_rds_cluster_id" {
   value       = "${aws_rds_cluster.this.id}"
 }
 
+output "this_rds_cluster_arn" {
+  description = "Amazon Resource Name (ARN) of cluster"
+  value       = "${aws_rds_cluster.this.arn}"
+}
+
 output "this_rds_cluster_resource_id" {
   description = "The Resource ID of the cluster"
   value       = "${aws_rds_cluster.this.cluster_resource_id}"
@@ -50,4 +55,9 @@ output "this_rds_cluster_instance_endpoints" {
 output "this_security_group_id" {
   description = "The security group ID of the cluster"
   value       = "${aws_security_group.this.id}"
+}
+
+output "this_rds_cluster_replication_source_identifier" {
+  description = "ARN of the source DB cluster or DB instance if this DB cluster is created as a Read Replica."
+  value       = "${aws_rds_cluster.this.replication_source_identifier}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -210,7 +210,8 @@ variable "replication_source_identifier" {
 variable "source_region" {
   description = "The source region for an encrypted replica DB cluster."
   default     = ""
-  
+}
+
 variable "vpc_security_group_ids" {
   description = "List of VPC security groups to associate to the cluster in addition to the SG we create in this module"
   type        = "list"

--- a/variables.tf
+++ b/variables.tf
@@ -201,3 +201,13 @@ variable "engine_mode" {
   description = "The database engine mode. Valid values: global, parallelquery, provisioned, serverless."
   default     = "provisioned"
 }
+
+variable "replication_source_identifier" {
+  description = "ARN of a source DB cluster or DB instance if this DB cluster is to be created as a Read Replica."
+  default     = ""
+}
+
+variable "source_region" {
+  description = "The source region for an encrypted replica DB cluster."
+  default     = ""
+}


### PR DESCRIPTION
# Description

Hi there.
I wanted to deploy a cross-region Aurora read replica cluster and could not do it from the actual module. I figured out that it was only the matter of two attributes to add so did it and deployed everything into our account.
Works greatly, I can give an example if tests needed.

The thing I did was just add the two attributes:

* [replication_source_identifier](https://www.terraform.io/docs/providers/aws/r/rds_cluster.html#replication_source_identifier)
* [source_region](https://www.terraform.io/docs/providers/aws/r/rds_cluster.html#source_region)

You need to put the ARN into the `replication_source_identifier` so I had to add the output `this_rds_cluster_arn` so I can get it via the Terraform states in another state (I use Terragrunt).
For encrypted database source you need to specify the `kms_key_id` which is the ARN of the local KMS Key (default to the aws/rds managed key works great).

If you have any review or question, I'm here to answer them.
