### PR TITLE
Add cluster ARN output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 |------|-------------|
 | this\_rds\_cluster\_database\_name | Name for an automatically created database on cluster creation |
 | this\_rds\_cluster\_endpoint | The cluster endpoint |
+| this\_rds\_cluster\_arn | The ARN of the cluster |
 | this\_rds\_cluster\_id | The ID of the cluster |
 | this\_rds\_cluster\_instance\_endpoints | A list of all cluster instance endpoints |
 | this\_rds\_cluster\_master\_password | The master password |

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,9 @@
 // aws_rds_cluster
+output "this_rds_cluster_arn" {
+  description = "The ID of the cluster"
+  value       = aws_rds_cluster.this.arn
+}
+
 output "this_rds_cluster_id" {
   description = "The ID of the cluster"
   value       = aws_rds_cluster.this.id


### PR DESCRIPTION
Adds the ARN of the Aurora Cluster as an output as `this_rds_cluster_arn`.
Fixes: #40 