### PR TITLE
vpc_security_group_ids for Terraform 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | tags | A map of tags to add to all resources. | map | `{}` | no |
 | username | Master DB username | string | `"root"` | no |
 | vpc\_id | VPC ID | string | n/a | yes |
+| vpc\_security\_group\_ids | List of VPC security groups to associate to the cluster in addition to the SG we create in this module | list | `[]` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "aws_rds_cluster" "this" {
   preferred_maintenance_window        = var.preferred_maintenance_window
   port                                = local.port
   db_subnet_group_name                = aws_db_subnet_group.this.name
-  vpc_security_group_ids              = [aws_security_group.this.id]
+  vpc_security_group_ids              = concat([aws_security_group.this.id], var.vpc_security_group_ids)
   snapshot_identifier                 = var.snapshot_identifier
   storage_encrypted                   = var.storage_encrypted
   apply_immediately                   = var.apply_immediately

--- a/variables.tf
+++ b/variables.tf
@@ -237,3 +237,8 @@ variable "engine_mode" {
   default     = "provisioned"
 }
 
+variable "vpc_security_group_ids" {
+  description = "List of VPC security groups to associate to the cluster in addition to the SG we create in this module"
+  type        = list
+  default     = []
+}


### PR DESCRIPTION
# Description

Similar to [PR 46](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/pull/46), we would like to support `vpc_security_group_ids` variable in the master branch (for Terraform 0.12.0 and up).