### PR TITLE
Add support to use existing subnet group name

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | database\_name | Name for an automatically created database on cluster creation | string | `""` | no |
 | db\_cluster\_parameter\_group\_name | The name of a DB Cluster parameter group to use | string | `"default.aurora5.6"` | no |
 | db\_parameter\_group\_name | The name of a DB parameter group to use | string | `"default.aurora5.6"` | no |
+| db\_subnet\_group\_name | The existing subnet group name to use | string | `""` | no |
 | deletion\_protection | If the DB instance should have deletion protection enabled | string | `"false"` | no |
 | enabled\_cloudwatch\_logs\_exports | List of log types to export to cloudwatch | list | `[]` | no |
 | engine | Aurora database engine type, currently aurora, aurora-mysql or aurora-postgresql | string | `"aurora"` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -242,3 +242,9 @@ variable "vpc_security_group_ids" {
   type        = list
   default     = []
 }
+
+variable "db_subnet_group_name" {
+  description = "The existing subnet group name to use"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
# Description

This feature is useful if RDS resources are imported to Terraform, and changing subnet group in Aurora cluster is not possible without recreating them.
