### PR TITLE
Add support for backtrack feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | allowed\_security\_groups\_count | The number of Security Groups being added, terraform doesn't let us use length() in a count field | string | `"0"` | no |
 | apply\_immediately | Determines whether or not any DB modifications are applied immediately, or during the maintenance window | bool | `"false"` | no |
 | auto\_minor\_version\_upgrade | Determines whether minor engine upgrades will be performed automatically in the maintenance window | bool | `"true"` | no |
+| backtrack\_window | How far back in time you might want to rewind (in seconds) | number | `"0"` | no |
 | backup\_retention\_period | How long to keep backups for (in days) | number | `"7"` | no |
 | database\_name | Name for an automatically created database on cluster creation | string | `""` | no |
 | db\_cluster\_parameter\_group\_name | The name of a DB Cluster parameter group to use | string | `"default.aurora5.6"` | no |

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,7 @@ locals {
   port                 = var.port == "" ? var.engine == "aurora-postgresql" ? "5432" : "3306" : var.port
   master_password      = var.password == "" ? random_id.master_password.b64 : var.password
   db_subnet_group_name = var.db_subnet_group_name == "" ? aws_db_subnet_group.this[0].name : var.db_subnet_group_name
+  backtrack_window     = var.engine == "aurora-mysql" || var.engine == "aurora" ? var.backtrack_window : 0
 }
 
 # Random string to use as master password unless one is specified
@@ -48,8 +49,8 @@ resource "aws_rds_cluster" "this" {
   apply_immediately                   = var.apply_immediately
   db_cluster_parameter_group_name     = var.db_cluster_parameter_group_name
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
-
-  enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
+  backtrack_window                    = local.backtrack_window
+  enabled_cloudwatch_logs_exports     = var.enabled_cloudwatch_logs_exports
 
   tags = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -249,3 +249,9 @@ variable "db_subnet_group_name" {
   type        = string
   default     = ""
 }
+
+variable "backtrack_window" {
+  description = "The target backtrack window in seconds"
+  type        = number
+  default     = 0
+}


### PR DESCRIPTION
# Description

This feature enables backtrack support on `aurora` and `aurora-mysql` clusters. My understanding is that this feature is not supported for `aurora-postgresql` and in that case setting `backtrack_window` will not have any effect.
