### PR TITLE
Add option to customise predefined_metric_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,12 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | performance\_insights\_enabled | Specifies whether Performance Insights is enabled or not. | bool | `"false"` | no |
 | performance\_insights\_kms\_key\_id | The ARN for the KMS key to encrypt Performance Insights data. | string | `""` | no |
 | port | The port on which to accept connections | string | `""` | no |
+| predefined\_metric\_type | The metric type to scale on. Valid values are RDSReaderAverageCPUUtilization and RDSReaderAverageDatabaseConnections. | string | `"RDSReaderAverageCPUUtilization"` | no |
 | preferred\_backup\_window | When to perform DB backups | string | `"02:00-03:00"` | no |
 | preferred\_maintenance\_window | When to perform DB maintenance | string | `"sun:05:00-sun:06:00"` | no |
 | publicly\_accessible | Whether the DB should have a public IP address | bool | `"false"` | no |
 | replica\_count | Number of reader nodes to create.  If `replica_scale_enable` is `true`, the value of `replica_scale_min` is used instead. | string | `"1"` | no |
+| replica\_scale\_connections | Average number of connections to trigger autoscaling at. Default value is 70% of db.r4.large's default max_connections: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Managing.Performance.html."| number | `"700"` | no |
 | replica\_scale\_cpu | CPU usage to trigger autoscaling at | number | `"70"` | no |
 | replica\_scale\_enabled | Whether to enable autoscaling for RDS Aurora (MySQL) read replicas | bool | `"false"` | no |
 | replica\_scale\_in\_cooldown | Cooldown in seconds before allowing further scaling operations after a scale in | number | `"300"` | no |

--- a/main.tf
+++ b/main.tf
@@ -131,12 +131,12 @@ resource "aws_appautoscaling_policy" "autoscaling_read_replica_count" {
 
   target_tracking_scaling_policy_configuration {
     predefined_metric_specification {
-      predefined_metric_type = "RDSReaderAverageCPUUtilization"
+      predefined_metric_type = var.predefined_metric_type
     }
 
     scale_in_cooldown  = var.replica_scale_in_cooldown
     scale_out_cooldown = var.replica_scale_out_cooldown
-    target_value       = var.replica_scale_cpu
+    target_value       = var.predefined_metric_type == "RDSReaderAverageCPUUtilization" ? var.replica_scale_cpu : var.replica_scale_connections
   }
 
   depends_on = [aws_appautoscaling_target.read_replica_count]

--- a/variables.tf
+++ b/variables.tf
@@ -184,6 +184,12 @@ variable "replica_scale_cpu" {
   default     = 70
 }
 
+variable "replica_scale_connections" {
+  description = "Average number of connections to trigger autoscaling at. Default value is 70% of db.r4.large's default max_connections"
+  type        = number
+  default     = 700
+}
+
 variable "replica_scale_in_cooldown" {
   description = "Cooldown in seconds before allowing further scaling operations after a scale in"
   type        = number
@@ -248,4 +254,9 @@ variable "db_subnet_group_name" {
   description = "The existing subnet group name to use"
   type        = string
   default     = ""
+}
+
+variable "predefined_metric_type" {
+  description = "The metric type to scale on. Valid values are RDSReaderAverageCPUUtilization and RDSReaderAverageDatabaseConnections."
+  default     = "RDSReaderAverageCPUUtilization"
 }


### PR DESCRIPTION
# Description

Added variable used to customise predefined metric type 

https://docs.aws.amazon.com/autoscaling/plans/APIReference/API_PredefinedScalingMetricSpecification.html