### PR TITLE
Fix the error when "create_security_group" is set to false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ resource "aws_rds_cluster" "this" {
   preferred_maintenance_window        = var.preferred_maintenance_window
   port                                = local.port
   db_subnet_group_name                = local.db_subnet_group_name
-  vpc_security_group_ids              = compact(concat([aws_security_group.this[0].id], var.vpc_security_group_ids))
+  vpc_security_group_ids              = compact(concat(aws_security_group.this.*.id, var.vpc_security_group_ids))
   snapshot_identifier                 = var.snapshot_identifier
   storage_encrypted                   = var.storage_encrypted
   apply_immediately                   = var.apply_immediately

--- a/outputs.tf
+++ b/outputs.tf
@@ -54,6 +54,6 @@ output "this_rds_cluster_instance_endpoints" {
 // aws_security_group
 output "this_security_group_id" {
   description = "The security group ID of the cluster"
-  value       = aws_security_group.this[0].id
+  value       = concat(aws_security_group.this.*.id, [""])[0]
 }
 


### PR DESCRIPTION
If the `create_security_group` var is set to `false`, then `aws_security_group.this[0]` is not defined, which causes errors (reproduced on terraform v0.12.12):
```
../terraform-aws-rds-aurora/outputs.tf line 57, in output "this_security_group_id":
  57:   value       = aws_security_group.this[0].id
    |----------------
    | aws_security_group.this is empty tuple
```
```
../terraform-aws-rds-aurora/main.tf line 48, in resource "aws_rds_cluster" "this":
  48:   vpc_security_group_ids              = compact(concat([aws_security_group.this[0].id], var.vpc_security_group_ids))
    |----------------
    | aws_security_group.this is empty tuple
```

This PR fixes that in a similar way how it's done in https://github.com/terraform-aws-modules/terraform-aws-vpc