### PR TITLE
feat: Add support for existing IAM role for enhanced monitoring

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.31.0
+    rev: v1.39.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v3.2.0
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | backup\_retention\_period | How long to keep backups for (in days) | `number` | `7` | no |
 | ca\_cert\_identifier | The identifier of the CA certificate for the DB instance | `string` | `"rds-ca-2019"` | no |
 | copy\_tags\_to\_snapshot | Copy all Cluster tags to snapshots. | `bool` | `false` | no |
+| create\_monitoring\_role | Whether to create the IAM role for RDS enhanced monitoring | `bool` | `true` | no |
 | create\_security\_group | Whether to create security group for RDS cluster | `bool` | `true` | no |
 | database\_name | Name for an automatically created database on cluster creation | `string` | `""` | no |
 | db\_cluster\_parameter\_group\_name | The name of a DB Cluster parameter group to use | `string` | `null` | no |
@@ -114,6 +115,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | instance\_type\_replica | Instance type to use at replica instance | `string` | `null` | no |
 | kms\_key\_id | The ARN for the KMS encryption key if one is set to the cluster. | `string` | `""` | no |
 | monitoring\_interval | The interval (seconds) between points when Enhanced Monitoring metrics are collected | `number` | `0` | no |
+| monitoring\_role\_arn | IAM role for RDS to send enhanced monitoring metrics to CloudWatch | `string` | `""` | no |
 | name | Name given resources | `string` | n/a | yes |
 | password | Master DB password | `string` | `""` | no |
 | performance\_insights\_enabled | Specifies whether Performance Insights is enabled or not. | `bool` | `false` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -120,6 +120,18 @@ variable "apply_immediately" {
   default     = false
 }
 
+variable "monitoring_role_arn" {
+  description = "IAM role for RDS to send enhanced monitoring metrics to CloudWatch"
+  type        = string
+  default     = ""
+}
+
+variable "create_monitoring_role" {
+  description = "Whether to create the IAM role for RDS enhanced monitoring"
+  type        = bool
+  default     = true
+}
+
 variable "monitoring_interval" {
   description = "The interval (seconds) between points when Enhanced Monitoring metrics are collected"
   type        = number


### PR DESCRIPTION
# Description

Add support for using an existing IAM role to send RDS enhanced monitoring metrics to CloudWatch Logs.

### Background:
If the module is used for provisioning multiple clusters in the same account, it will create one monitoring role for each, which isn't really necessary as they're identical - attaching the same AWS managed policy - `AmazonRDSEnhancedMonitoringRole`.

Also, when enabling via the console, from [the docs](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.html#USER_Monitoring.OS.Enabling.Prerequisites):
> The first time that you enable Enhanced Monitoring in the console, you can select the **Default** option for the **Monitoring Role** property to have RDS create the required IAM role. RDS then automatically creates a role named `rds-monitoring-role` for you, and uses it for the specified DB instance or Read Replica.

### Testing:
Added the below to an existing cluster:
```hcl
data "aws_iam_role" "default_aws_rds_monitoring_role" {
  name = "rds-monitoring-role"
}

module "ods2" {
  source                 = "terraform-aws-modules/rds-aurora/aws"
  (...)
  create_monitoring_role = false
  monitoring_interval    = 60
  monitoring_role_arn    = data.aws_iam_role.default_aws_rds_monitoring_role.arn
}
```
Generated these changes:
```
      ~ monitoring_interval = 0 -> 60
      + monitoring_role_arn = "arn:aws:iam::<REMOVED>:role/rds-monitoring-role"
```