### PR TITLE
Add security group name and description

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,13 @@
 locals {
   port                 = var.port == "" ? var.engine == "aurora-postgresql" ? "5432" : "3306" : var.port
   master_password      = var.password == "" ? random_id.master_password.b64 : var.password
-  db_subnet_group_name = var.db_subnet_group_name == "" ? aws_db_subnet_group.this[0].name : var.db_subnet_group_name
+  db_subnet_group_name = var.db_subnet_group_name == "" ? join("", aws_db_subnet_group.this.*.name) : var.db_subnet_group_name
   backtrack_window     = (var.engine == "aurora-mysql" || var.engine == "aurora") && var.engine_mode != "serverless" ? var.backtrack_window : 0
+
+  rds_enhanced_monitoring_arn  = join("", aws_iam_role.rds_enhanced_monitoring.*.arn)
+  rds_enhanced_monitoring_name = join("", aws_iam_role.rds_enhanced_monitoring.*.name)
+
+  rds_security_group_id = join("", aws_security_group.this.*.id)
 
   name = "aurora-${var.name}"
 }
@@ -85,7 +90,7 @@ resource "aws_rds_cluster_instance" "this" {
   db_parameter_group_name         = var.db_parameter_group_name
   preferred_maintenance_window    = var.preferred_maintenance_window
   apply_immediately               = var.apply_immediately
-  monitoring_role_arn             = join("", aws_iam_role.rds_enhanced_monitoring.*.arn)
+  monitoring_role_arn             = local.rds_enhanced_monitoring_arn
   monitoring_interval             = var.monitoring_interval
   auto_minor_version_upgrade      = var.auto_minor_version_upgrade
   promotion_tier                  = count.index + 1
@@ -124,7 +129,7 @@ resource "aws_iam_role" "rds_enhanced_monitoring" {
 resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
   count = var.monitoring_interval > 0 ? 1 : 0
 
-  role       = aws_iam_role.rds_enhanced_monitoring[0].name
+  role       = local.rds_enhanced_monitoring_name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
 }
 
@@ -183,7 +188,7 @@ resource "aws_security_group_rule" "default_ingress" {
   to_port                  = aws_rds_cluster.this.port
   protocol                 = "tcp"
   source_security_group_id = element(var.allowed_security_groups, count.index)
-  security_group_id        = aws_security_group.this[0].id
+  security_group_id        = local.rds_security_group_id
 }
 
 resource "aws_security_group_rule" "cidr_ingress" {
@@ -196,5 +201,5 @@ resource "aws_security_group_rule" "cidr_ingress" {
   to_port           = aws_rds_cluster.this.port
   protocol          = "tcp"
   cidr_blocks       = var.allowed_cidr_blocks
-  security_group_id = aws_security_group.this[0].id
+  security_group_id = local.rds_security_group_id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -54,6 +54,6 @@ output "this_rds_cluster_instance_endpoints" {
 // aws_security_group
 output "this_security_group_id" {
   description = "The security group ID of the cluster"
-  value       = concat(aws_security_group.this.*.id, [""])[0]
+  value       = local.rds_security_group_id
 }
 


### PR DESCRIPTION
# Description

This PR adds name (tag) and description attributes to the security group and its rules.

In addition, to prevent errors when (for example) importing resources with this module present in the configuration, this PR also replaces the hard-coded access to index 0 of conditional resources by a call to `join` function using the splat notation.

An example of the error I was getting while importing resources form other modules, while having this module in my terraform config:
```
Error: Invalid index

  on ../../modules/aws-rds-aurora/main.tf line 4, in locals:
   4:   db_subnet_group_name = var.db_subnet_group_name == "" ? aws_db_subnet_group.this[0].name : var.db_subnet_group_name
    |----------------
    | aws_db_subnet_group.this is empty tuple
```
