### PR TITLE
Update note for parameter group family in example main.tf

### DIFF
--- a/examples/postgresql/main.tf
+++ b/examples/postgresql/main.tf
@@ -31,6 +31,8 @@ module "aurora" {
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.aurora_cluster_postgres96_parameter_group.id
   //  enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
 }
+  
+# If you want to use newest parameter group family just use value "aurora-postgresql10" for family variable below.
 
 resource "aws_db_parameter_group" "aurora_db_postgres96_parameter_group" {
   name        = "test-aurora-db-postgres96-parameter-group"


### PR DESCRIPTION
# Description

Unfortunately unclear how to use newest aurora PostgreSQL version.
Notes have been added to example file how you can use it.
For example:
`family      = "aurora-postgresql10"`
that value was explored here:
`aws rds describe-db-engine-versions --query "DBEngineVersions[].DBParameterGroupFamily"`