### PR TITLE
Revert "add support for ca_cert_identifier option" (fixed v1.20.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | auto\_minor\_version\_upgrade | Determines whether minor engine upgrades will be performed automatically in the maintenance window | string | `"true"` | no |
 | backtrack\_window | The target backtrack window, in seconds. Only available for aurora engine currently. To disable backtracking, set this value to 0. Defaults to 0. Must be between 0 and 259200 (72 hours) | string | `"0"` | no |
 | backup\_retention\_period | How long to keep backups for (in days) | string | `"7"` | no |
-| ca\_cert\_identifier | Specifies the identifier of the CA certificate for the DB instance | string | `"rds-ca-2015"` | no |
 | copy\_tags\_to\_snapshot | Indicates whether to copy all of the user-defined tags from the DB instance to snapshots of the DB instance. | string | `"false"` | no |
 | database\_name | Name for an automatically created database on cluster creation | string | `""` | no |
 | db\_cluster\_parameter\_group\_name | The name of a DB Cluster parameter group to use | string | `"default.aurora5.6"` | no |

--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,6 @@ resource "aws_rds_cluster" "this" {
   db_cluster_parameter_group_name     = "${var.db_cluster_parameter_group_name}"
   iam_database_authentication_enabled = "${var.iam_database_authentication_enabled}"
   backtrack_window                    = "${local.backtrack_window}"
-  ca_cert_identifier                  = "${var.ca_cert_identifier}"
 
   enabled_cloudwatch_logs_exports = "${var.enabled_cloudwatch_logs_exports}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -244,8 +244,3 @@ variable "copy_tags_to_snapshot" {
   description = "Indicates whether to copy all of the user-defined tags from the DB instance to snapshots of the DB instance."
   default     = false
 }
-
-variable "ca_cert_identifier" {
-  description = "Specifies the identifier of the CA certificate for the DB instance. Possible values `rds-ca-2015` | `rds-ca-2019`"
-  default     = "rds-ca-2015"
-}


### PR DESCRIPTION
Reverts terraform-aws-modules/terraform-aws-rds-aurora#83

RDS Aurora does not support ca_cert_identifier.