### PR TITLE
[WIP] Add variable to override description of SG

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | replica\_scale\_out\_cooldown | Cooldown in seconds before allowing further scaling operations after a scale out | number | `"300"` | no |
 | replication\_source\_identifier | ARN of a source DB cluster or DB instance if this DB cluster is to be created as a Read Replica. | string | `""` | no |
 | scaling\_configuration | Map of nested attributes with scaling properties. Only valid when engine_mode is set to `serverless` | map(string) | `{}` | no |
+| security\_group\_description | The descriptiont text to be set on the security group. This flag can make upgrading the module easier by preventing a recration of the SG when the description changes | string | `"null"` | no |
 | skip\_final\_snapshot | Should a final snapshot be created on cluster destroy | bool | `"false"` | no |
 | snapshot\_identifier | DB snapshot to create this database from | string | `""` | no |
 | source\_region | The source region for an encrypted replica DB cluster. | string | `""` | no |

--- a/examples/issue-84-security-group-description/main.tf
+++ b/examples/issue-84-security-group-description/main.tf
@@ -1,0 +1,91 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+######################################
+# Data sources to get VPC and subnets
+######################################
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnet_ids" "all" {
+  vpc_id = data.aws_vpc.default.id
+}
+
+#############
+# RDS Aurora
+#############
+module "aurora" {
+  source                              = "../../"
+  name                                = "aurora-example-mysql"
+  engine                              = "aurora-mysql"
+  engine_version                      = "5.7.12"
+  subnets                             = data.aws_subnet_ids.all.ids
+  vpc_id                              = data.aws_vpc.default.id
+  replica_count                       = 0
+  instance_type                       = "db.t2.medium"
+  apply_immediately                   = true
+  skip_final_snapshot                 = true
+  db_parameter_group_name             = aws_db_parameter_group.aurora_db_57_parameter_group.id
+  db_cluster_parameter_group_name     = aws_rds_cluster_parameter_group.aurora_57_cluster_parameter_group.id
+  iam_database_authentication_enabled = true
+  enabled_cloudwatch_logs_exports     = ["audit", "error", "general", "slowquery"]
+  allowed_cidr_blocks                 = ["10.20.0.0/20", "20.20.0.0/20"]
+
+  create_security_group = true
+
+  security_group_description = "Managed by Terraform"
+}
+
+resource "aws_db_parameter_group" "aurora_db_57_parameter_group" {
+  name        = "test-aurora-db-57-parameter-group"
+  family      = "aurora-mysql5.7"
+  description = "test-aurora-db-57-parameter-group"
+}
+
+resource "aws_rds_cluster_parameter_group" "aurora_57_cluster_parameter_group" {
+  name        = "test-aurora-57-cluster-parameter-group"
+  family      = "aurora-mysql5.7"
+  description = "test-aurora-57-cluster-parameter-group"
+}
+
+############################
+# Example of security group
+############################
+resource "aws_security_group" "app_servers" {
+  name_prefix = "app-servers-"
+  description = "For application servers"
+  vpc_id      = data.aws_vpc.default.id
+}
+
+resource "aws_security_group_rule" "allow_access" {
+  type                     = "ingress"
+  from_port                = module.aurora.this_rds_cluster_port
+  to_port                  = module.aurora.this_rds_cluster_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.app_servers.id
+  security_group_id        = module.aurora.this_security_group_id
+}
+
+# IAM Policy for use with iam_database_authentication_enabled = true
+resource "aws_iam_policy" "aurora_mysql_policy_iam_auth" {
+  name = "test-aurora-db-57-policy-iam-auth"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "rds-db:connect"
+      ],
+      "Resource": [
+        "arn:aws:rds-db:us-east-1:123456789012:dbuser:${module.aurora.this_rds_cluster_resource_id}/jane_doe"
+      ]
+    }
+  ]
+}
+POLICY
+}

--- a/examples/issue-84-security-group-description/outputs.tf
+++ b/examples/issue-84-security-group-description/outputs.tf
@@ -1,0 +1,53 @@
+// aws_rds_cluster
+output "this_rds_cluster_id" {
+  description = "The ID of the cluster"
+  value       = module.aurora.this_rds_cluster_id
+}
+
+output "this_rds_cluster_resource_id" {
+  description = "The Resource ID of the cluster"
+  value       = module.aurora.this_rds_cluster_resource_id
+}
+
+output "this_rds_cluster_endpoint" {
+  description = "The cluster endpoint"
+  value       = module.aurora.this_rds_cluster_endpoint
+}
+
+output "this_rds_cluster_reader_endpoint" {
+  description = "The cluster reader endpoint"
+  value       = module.aurora.this_rds_cluster_reader_endpoint
+}
+
+output "this_rds_cluster_database_name" {
+  description = "Name for an automatically created database on cluster creation"
+  value       = module.aurora.this_rds_cluster_database_name
+}
+
+output "this_rds_cluster_master_password" {
+  description = "The master password"
+  value       = module.aurora.this_rds_cluster_master_password
+}
+
+output "this_rds_cluster_port" {
+  description = "The port"
+  value       = module.aurora.this_rds_cluster_port
+}
+
+output "this_rds_cluster_master_username" {
+  description = "The master username"
+  value       = module.aurora.this_rds_cluster_master_username
+}
+
+// aws_rds_cluster_instance
+output "this_rds_cluster_instance_endpoints" {
+  description = "A list of all cluster instance endpoints"
+  value       = module.aurora.this_rds_cluster_instance_endpoints
+}
+
+// aws_security_group
+output "this_security_group_id" {
+  description = "The security group ID of the cluster"
+  value       = module.aurora.this_security_group_id
+}
+

--- a/main.tf
+++ b/main.tf
@@ -171,7 +171,7 @@ resource "aws_security_group" "this" {
   name_prefix = "${var.name}-"
   vpc_id      = var.vpc_id
 
-  description = "Control traffic to/from RDS Aurora ${var.name}"
+  description = var.security_group_description != null ? var.security_group_description : "Control traffic to/from RDS Aurora ${var.name}"
 
   tags = merge(var.tags, {
     Name = local.name

--- a/variables.tf
+++ b/variables.tf
@@ -295,8 +295,15 @@ variable "copy_tags_to_snapshot" {
   type        = bool
   default     = false
 }
+
 variable "iam_roles" {
   description = "A List of ARNs for the IAM roles to associate to the RDS Cluster."
   type        = list(string)
   default     = []
+}
+
+variable "security_group_description" {
+  description = "The descriptiont text to be set on the security group. This flag can make upgrading the module easier by preventing a recration of the SG when the description changes"
+  type        = string
+  default     = null
 }


### PR DESCRIPTION
# Description

This PR adds a variable to allow users of the module to override the description set on the created security group. This way, when that description changes (and it did in v2.10.0) users can still keep the previous description which should then make it possible to not re-create the security group.