### PR TITLE
Hide sensitive password data from cli output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -33,6 +33,7 @@ output "this_rds_cluster_database_name" {
 output "this_rds_cluster_master_password" {
   description = "The master password"
   value       = aws_rds_cluster.this.master_password
+  sensitive   = true
 }
 
 output "this_rds_cluster_port" {


### PR DESCRIPTION
# Description

The password should not be printed to stdout by the cli, since it is
sensitive data.

Hiding sensitive data is a must-have when running Terraform in CD
environments. It is good practice to hide sensitive data from CI/CD logs.

See official Terraform docs for details:
https://www.terraform.io/docs/configuration/outputs.html#sensitive-suppressing-values-in-cli-output
