### PR TITLE
Added missing type type for allowed_security_groups variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,7 @@ variable "replica_count" {
 
 variable "allowed_security_groups" {
   description = "A list of Security Group ID's to allow access to."
+  type        = list(string)
   default     = []
 }
 


### PR DESCRIPTION
 allowed_security_groups variable is described, and used, as a list so should have the type constraints added
