### PR TITLE
Adding support for ca_cert_identifier for the upcoming RDS cert updat…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -96,6 +96,7 @@ resource "aws_rds_cluster_instance" "this" {
   promotion_tier                  = count.index + 1
   performance_insights_enabled    = var.performance_insights_enabled
   performance_insights_kms_key_id = var.performance_insights_kms_key_id
+  ca_cert_identifier              = var.ca_cert_identifier
 
   tags = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -307,3 +307,9 @@ variable "security_group_description" {
   type        = string
   default     = "Managed by Terraform"
 }
+
+variable "ca_cert_identifier" {
+  description = "The identifier of the CA certificate for the DB instance"
+  type        = string
+  default     = "rds-ca-2019"
+}


### PR DESCRIPTION
…e on 5 March 2020  (#91)

# Description
Adding support to specify and update the "Certificate authority" on RDS for the upcoming certificate rotation by AWS. The default is "rds-ca-2019".
