### PR TITLE
Add permissions boundary aws iam role

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | password | Master DB password | `string` | `""` | no |
 | performance\_insights\_enabled | Specifies whether Performance Insights is enabled or not. | `bool` | `false` | no |
 | performance\_insights\_kms\_key\_id | The ARN for the KMS key to encrypt Performance Insights data. | `string` | `""` | no |
+| permissions\_boundary | The ARN of the policy that is used to set the permissions boundary for the role. | `string` | `""` | no |
 | port | The port on which to accept connections | `string` | `""` | no |
 | predefined\_metric\_type | The metric type to scale on. Valid values are RDSReaderAverageCPUUtilization and RDSReaderAverageDatabaseConnections. | `string` | `"RDSReaderAverageCPUUtilization"` | no |
 | preferred\_backup\_window | When to perform DB backups | `string` | `"02:00-03:00"` | no |

--- a/main.tf
+++ b/main.tf
@@ -125,6 +125,8 @@ resource "aws_iam_role" "rds_enhanced_monitoring" {
 
   name               = "rds-enhanced-monitoring-${var.name}"
   assume_role_policy = data.aws_iam_policy_document.monitoring_rds_assume_role.json
+  
+  permissions_boundary = var.permissions_boundary
 }
 
 resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {

--- a/variables.tf
+++ b/variables.tf
@@ -307,3 +307,9 @@ variable "security_group_description" {
   type        = string
   default     = "Managed by Terraform"
 }
+
+variable "permissions_boundary" {
+  description = "The ARN of the policy that is used to set the permissions boundary for the role."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
# Description

This PR will allow creating "aws_iam_role" "rds_enhanced_monitoring" when AWS is set to use permissions boundary in an IAM role creation.