### PR TITLE
Separated maintenance window for cluster and instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | port | The port on which to accept connections | `string` | `""` | no |
 | predefined\_metric\_type | The metric type to scale on. Valid values are RDSReaderAverageCPUUtilization and RDSReaderAverageDatabaseConnections. | `string` | `"RDSReaderAverageCPUUtilization"` | no |
 | preferred\_backup\_window | When to perform DB backups | `string` | `"02:00-03:00"` | no |
-| preferred\_maintenance\_window | When to perform DB maintenance | `string` | `"sun:05:00-sun:06:00"` | no |
+| preferred\_maintenance\_window | When to perform DB maintenance - Deprecated use specific cluster/instance maintenance window instead| `string` | `"sun:05:00-sun:06:00"` | no |
+| preferred\_cluster_maintenance\_window | When to perform DB maintenance on the cluster | `string` | `"sun:05:00-sun:06:00"` | no |
+| preferred\_instance_maintenance\_window | When to perform DB maintenance on the instances| `string` | `"sun:05:00-sun:06:00"` | no |
 | publicly\_accessible | Whether the DB should have a public IP address | `bool` | `false` | no |
 | replica\_count | Number of reader nodes to create.  If `replica_scale_enable` is `true`, the value of `replica_scale_min` is used instead. | `number` | `1` | no |
 | replica\_scale\_connections | Average number of connections to trigger autoscaling at. Default value is 70% of db.r4.large's default max\_connections | `number` | `700` | no |

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -17,23 +17,25 @@ data "aws_subnet_ids" "all" {
 # RDS Aurora
 #############
 module "aurora" {
-  source                          = "../../"
-  name                            = "aurora-example"
-  engine                          = "aurora-postgresql"
-  engine_version                  = "10.4"
-  subnets                         = data.aws_subnet_ids.all.ids
-  vpc_id                          = data.aws_vpc.default.id
-  replica_count                   = 1
-  replica_scale_enabled           = true
-  replica_scale_min               = 1
-  replica_scale_max               = 5
-  monitoring_interval             = 60
-  instance_type                   = "db.r4.large"
-  apply_immediately               = true
-  skip_final_snapshot             = true
-  db_parameter_group_name         = aws_db_parameter_group.aurora_db_postgres96_parameter_group.id
-  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.aurora_cluster_postgres96_parameter_group.id
-  //  enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
+  source                                = "../../"
+  name                                  = "aurora-example"
+  engine                                = "aurora-postgresql"
+  engine_version                        = "10.4"
+  subnets                               = data.aws_subnet_ids.all.ids
+  vpc_id                                = data.aws_vpc.default.id
+  replica_count                         = 1
+  replica_scale_enabled                 = true
+  replica_scale_min                     = 1
+  replica_scale_max                     = 5
+  preferred_cluster_maintenance_window  = "wed:04:30-wed:05:00"
+  preferred_instance_maintenance_window = "wed:04:00-wed:04:30"
+  monitoring_interval                   = 60
+  instance_type                         = "db.r4.large"
+  apply_immediately                     = true
+  skip_final_snapshot                   = true
+  db_parameter_group_name               = aws_db_parameter_group.aurora_db_postgres96_parameter_group.id
+  db_cluster_parameter_group_name       = aws_rds_cluster_parameter_group.aurora_cluster_postgres96_parameter_group.id
+  //  enabled_cloudwatch_logs_exports     = ["audit", "error", "general", "slowquery"]
 }
 
 resource "aws_db_parameter_group" "aurora_db_postgres96_parameter_group" {

--- a/examples/mysql/main.tf
+++ b/examples/mysql/main.tf
@@ -32,6 +32,7 @@ module "aurora" {
   iam_database_authentication_enabled = true
   enabled_cloudwatch_logs_exports     = ["audit", "error", "general", "slowquery"]
   allowed_cidr_blocks                 = ["10.20.0.0/20", "20.20.0.0/20"]
+  preferred_maintenance_window        = "wed:04:00-wed:04:30"
 
   create_security_group = true
 }

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,9 @@ locals {
   db_subnet_group_name = var.db_subnet_group_name == "" ? join("", aws_db_subnet_group.this.*.name) : var.db_subnet_group_name
   backtrack_window     = (var.engine == "aurora-mysql" || var.engine == "aurora") && var.engine_mode != "serverless" ? var.backtrack_window : 0
 
+  preferred_cluster_maintenance_window  = var.preferred_maintenance_window == "" ? var.preferred_cluster_maintenance_window : var.preferred_maintenance_window
+  preferred_instance_maintenance_window = var.preferred_maintenance_window == "" ? var.preferred_instance_maintenance_window : var.preferred_maintenance_window
+
   rds_enhanced_monitoring_arn  = join("", aws_iam_role.rds_enhanced_monitoring.*.arn)
   rds_enhanced_monitoring_name = join("", aws_iam_role.rds_enhanced_monitoring.*.name)
 
@@ -47,7 +50,7 @@ resource "aws_rds_cluster" "this" {
   deletion_protection                 = var.deletion_protection
   backup_retention_period             = var.backup_retention_period
   preferred_backup_window             = var.preferred_backup_window
-  preferred_maintenance_window        = var.preferred_maintenance_window
+  preferred_maintenance_window        = local.preferred_cluster_maintenance_window
   port                                = local.port
   db_subnet_group_name                = local.db_subnet_group_name
   vpc_security_group_ids              = compact(concat(aws_security_group.this.*.id, var.vpc_security_group_ids))
@@ -89,7 +92,7 @@ resource "aws_rds_cluster_instance" "this" {
   publicly_accessible             = var.publicly_accessible
   db_subnet_group_name            = local.db_subnet_group_name
   db_parameter_group_name         = var.db_parameter_group_name
-  preferred_maintenance_window    = var.preferred_maintenance_window
+  preferred_maintenance_window    = local.preferred_instance_maintenance_window
   apply_immediately               = var.apply_immediately
   monitoring_role_arn             = local.rds_enhanced_monitoring_arn
   monitoring_interval             = var.monitoring_interval

--- a/variables.tf
+++ b/variables.tf
@@ -97,7 +97,19 @@ variable "preferred_backup_window" {
 }
 
 variable "preferred_maintenance_window" {
-  description = "When to perform DB maintenance"
+  description = "DEPRECATED, use cluster/instance maintenance window instead. Kept a little longer for backwards compatibility."
+  type        = string
+  default     = ""
+}
+
+variable "preferred_cluster_maintenance_window" {
+  description = "When to perform maintenance on the cluster"
+  type        = string
+  default     = "sun:05:00-sun:06:00"
+}
+
+variable "preferred_instance_maintenance_window" {
+  description = "When to perform maintenance on the instances"
   type        = string
   default     = "sun:05:00-sun:06:00"
 }


### PR DESCRIPTION
# Description

Added separation of the maintenance window setting so that we can set different times for clusters and instances. Since that is possible to do in the aws GUI.