### PR TITLE
feat: Support enable_http_endpoint - Data API (#59)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,7 @@ resource "aws_rds_cluster" "this" {
   engine                              = var.engine
   engine_mode                         = var.engine_mode
   engine_version                      = var.engine_version
+  enable_http_endpoint                = var.enable_http_endpoint
   kms_key_id                          = var.kms_key_id
   database_name                       = var.database_name
   master_username                     = var.username

--- a/variables.tf
+++ b/variables.tf
@@ -174,6 +174,12 @@ variable "engine_version" {
   default     = "5.6.10a"
 }
 
+variable "enable_http_endpoint" {
+  description = "Whether or not to enable the Data API for a serverless Aurora database engine."
+  type        = bool
+  default     = false
+}
+
 variable "replica_scale_enabled" {
   description = "Whether to enable autoscaling for RDS Aurora (MySQL) read replicas"
   type        = bool

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    aws    = "~> 2.0"
+    aws    = "~> 2.45"
     random = "~> 2.2"
   }
 }


### PR DESCRIPTION
## Description
This PR adds support for the Aurora Serverless Data API added in https://github.com/terraform-providers/terraform-provider-aws/pull/11048.

## Motivation and Context
Fixes #59 

## Breaking Changes
No breaking changes. The default is false, the same as it was when this module wasn't specifying it

## How Has This Been Tested?
I've tested this in my own Terraform stack.

`terraform plan` diff:
```
-/+ resource "aws_rds_cluster" "this" {
...
      ~ enable_http_endpoint                = false -> true
...
}
```