### PR TITLE
feat: Add snapshot_identifier to ignore_changes lifecycle

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -77,6 +77,10 @@ resource "aws_rds_cluster" "this" {
   }
 
   tags = var.tags
+  
+  lifecycle {
+    ignore_changes = snapshot_identifier
+  }
 }
 
 resource "aws_rds_cluster_instance" "this" {

--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,7 @@ resource "aws_rds_cluster" "this" {
   tags = var.tags
   
   lifecycle {
-    ignore_changes = snapshot_identifier
+    ignore_changes = [snapshot_identifier]
   }
 }
 


### PR DESCRIPTION
## Description
Add lifecycle to ignore snapshot_identifie changes in resource aws_rds_cluster.

## Motivation and Context
When using aws_db_cluster_snapshot data to get last snapshot to pass it to the module
```
data "aws_db_cluster_snapshot" "test" {
  db_cluster_identifier = "test"
  most_recent           = true
}
```

`snapshot_identifier             = data.aws_db_cluster_snapshot.test.id`

It tries to replace resource "aws_rds_cluster" everytime it finds a new one.

## Breaking Changes
No


