### PR TITLE
Added support for importing a backup from S3 for Aurora MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | username | Master DB username | `string` | `"root"` | no |
 | vpc\_id | VPC ID | `string` | n/a | yes |
 | vpc\_security\_group\_ids | List of VPC security groups to associate to the cluster in addition to the SG we create in this module | `list(string)` | `[]` | no |
+| s3_import_bucket_name | The bucket name where your backup is stored. Currently, this only works for the MySQL engine | `string` | `""` |
+| s3_import_bucket_prefix | Path to your backup within your S3 bucket. Can we blank. | `string` | `""` |
+| s3_import_ingestion_role | The role ARN to be used to load the data | `string` | `""` |
+| s3_import_source_engine | The engine of your source database. Currently, only one value accepted: `mysql` | `string` | `"mysql"` |
+| s3_import_source_engine_version | Version of your source engine used to make the backup. Specify the minor version as well. E.g.: `5.6.41` | `string` | `""` |
+
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -131,10 +131,15 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | replica\_scale\_min | Minimum number of replicas to allow scaling for | `number` | `2` | no |
 | replica\_scale\_out\_cooldown | Cooldown in seconds before allowing further scaling operations after a scale out | `number` | `300` | no |
 | replication\_source\_identifier | ARN of a source DB cluster or DB instance if this DB cluster is to be created as a Read Replica. | `string` | `""` | no |
+| s3_import_bucket_name | The bucket name where your backup is stored. Currently, this only works for the MySQL engine. This cannot be used in conjunction with the variable `snapshot_identifier`. | `string` | `""` |
+| s3_import_bucket_prefix | Path to your backup within your S3 bucket. Can we blank. | `string` | `""` |
+| s3_import_ingestion_role | The role ARN to be used to load the data | `string` | `""` |
+| s3_import_source_engine | The engine of your source database. Currently, only one value accepted: `mysql` | `string` | `"mysql"` |
+| s3_import_source_engine_version | Version of your source engine used to make the backup. Specify the minor version as well. E.g.: `5.6.41` | `string` | `""` |
 | scaling\_configuration | Map of nested attributes with scaling properties. Only valid when engine\_mode is set to `serverless` | `map(string)` | `{}` | no |
 | security\_group\_description | The description of the security group. If value is set to empty string it will contain cluster name in the description. | `string` | `"Managed by Terraform"` | no |
 | skip\_final\_snapshot | Should a final snapshot be created on cluster destroy | `bool` | `false` | no |
-| snapshot\_identifier | DB snapshot to create this database from | `string` | `""` | no |
+| snapshot\_identifier |DB snapshot to create this database from. This cannot be defined if you are trying to import your database from an S3 bucket | `string` | `""` | no |
 | source\_region | The source region for an encrypted replica DB cluster. | `string` | `""` | no |
 | storage\_encrypted | Specifies whether the underlying storage layer should be encrypted | `bool` | `true` | no |
 | subnets | List of subnet IDs to use | `list(string)` | `[]` | no |
@@ -142,11 +147,6 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | username | Master DB username | `string` | `"root"` | no |
 | vpc\_id | VPC ID | `string` | n/a | yes |
 | vpc\_security\_group\_ids | List of VPC security groups to associate to the cluster in addition to the SG we create in this module | `list(string)` | `[]` | no |
-| s3_import_bucket_name | The bucket name where your backup is stored. Currently, this only works for the MySQL engine | `string` | `""` |
-| s3_import_bucket_prefix | Path to your backup within your S3 bucket. Can we blank. | `string` | `""` |
-| s3_import_ingestion_role | The role ARN to be used to load the data | `string` | `""` |
-| s3_import_source_engine | The engine of your source database. Currently, only one value accepted: `mysql` | `string` | `"mysql"` |
-| s3_import_source_engine_version | Version of your source engine used to make the backup. Specify the minor version as well. E.g.: `5.6.41` | `string` | `""` |
 
 
 ## Outputs

--- a/examples/mysql-s3import/main.tf
+++ b/examples/mysql-s3import/main.tf
@@ -1,0 +1,120 @@
+provider "aws" {
+  region = "us-west-2"  
+}
+
+######################################
+# Data sources to get VPC and subnets
+######################################
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnet_ids" "all" {
+  vpc_id = data.aws_vpc.default.id
+}
+
+##############################################
+# Vars that are being used in multiple places
+##############################################
+locals {
+  s3_import_bucket_name               = "mysql-s3-restore"
+  s3_import_bucket_prefix             = "percona-backup/"
+}
+
+
+#############
+# RDS Aurora
+#############
+
+module "aurora" {
+  source                              = "../../"
+  name                                = "aurora-example-mysql"
+  engine                              = "aurora"
+  engine_version                      = "5.6.mysql_aurora.1.22.2"
+  subnets                             = data.aws_subnet_ids.all.ids
+  vpc_id                              = data.aws_vpc.default.id
+  replica_count                       = 1
+  instance_type                       = "db.t2.medium"
+  apply_immediately                   = true
+  skip_final_snapshot                 = true
+  iam_database_authentication_enabled = true
+  enabled_cloudwatch_logs_exports     = ["audit", "error", "general", "slowquery"]
+  allowed_cidr_blocks                 = ["10.20.0.0/20", "20.20.0.0/20"]
+  password                            = "Password123"
+
+  # Assumes that the bucket already exists and the backup already resides in the s3 bucket
+  s3_import_bucket_name               = local.s3_import_bucket_name
+  s3_import_bucket_prefix             = local.s3_import_bucket_prefix
+  # The following condition allows the module to have a dependency on the policy attachment
+  s3_import_ingestion_role            = aws_iam_role_policy_attachment.s3_import_role_policy_attachment.role != "" ? aws_iam_role.aurora_mysql_policy_iam_auth.arn : ""
+  s3_import_source_engine             = "mysql"
+  s3_import_source_engine_version     = "5.6.41"
+  
+  tags                                = {
+    Environment = "dev"
+    Terraform   = "true"
+    }
+}
+
+
+##################################
+# IAM Policy & Role for S3 Import
+##################################
+
+resource "aws_iam_policy" "s3_rds_import_policy" {
+    name = "s3_import_rds_tf_policy"
+    path = "/"
+    description = "Policy used to grant required access for RDS to import your backup from S3"
+    policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket",
+                "s3:GetBucketLocation"
+            ],
+            "Resource": [
+                "arn:aws:s3:::${local.s3_import_bucket_name}"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::${local.s3_import_bucket_name}/${local.s3_import_bucket_prefix}*"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+
+resource "aws_iam_role" "aurora_mysql_policy_iam_auth" {
+  name = "test-aurora-db-s3-import-policy-iam-auth"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Principal": {"Service": "rds.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }
+}
+  EOF
+
+  tags = {
+    Environment = "dev"
+    Terraform   = "true"
+    }
+}
+
+resource "aws_iam_role_policy_attachment" "s3_import_role_policy_attachment" {
+    role = aws_iam_role.aurora_mysql_policy_iam_auth.name
+    policy_arn = aws_iam_policy.s3_rds_import_policy.arn
+}

--- a/examples/mysql-s3import/outputs.tf
+++ b/examples/mysql-s3import/outputs.tf
@@ -1,0 +1,36 @@
+// aws_rds_cluster
+output "this_rds_cluster_id" {
+  description = "The ID of the cluster"
+  value       = module.aurora.this_rds_cluster_id
+}
+
+output "this_rds_cluster_resource_id" {
+  description = "The Resource ID of the cluster"
+  value       = module.aurora.this_rds_cluster_resource_id
+}
+
+output "this_rds_cluster_endpoint" {
+  description = "The cluster endpoint"
+  value       = module.aurora.this_rds_cluster_endpoint
+}
+
+
+output "this_rds_cluster_database_name" {
+  description = "Name for an automatically created database on cluster creation"
+  value       = module.aurora.this_rds_cluster_database_name
+}
+
+output "this_rds_cluster_master_password" {
+  description = "The master password"
+  value       = module.aurora.this_rds_cluster_master_password
+}
+
+output "this_rds_cluster_port" {
+  description = "The port"
+  value       = module.aurora.this_rds_cluster_port
+}
+
+output "this_rds_cluster_master_username" {
+  description = "The master username"
+  value       = module.aurora.this_rds_cluster_master_username
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,27 +1,27 @@
 // aws_rds_cluster
 output "this_rds_cluster_arn" {
   description = "The ID of the cluster"
-  value       = aws_rds_cluster.this.arn
+  value       = element(concat(aws_rds_cluster.this.*.arn, aws_rds_cluster.this-s3-restore.*.arn), 0)
 }
 
 output "this_rds_cluster_id" {
   description = "The ID of the cluster"
-  value       = aws_rds_cluster.this.id
+  value       = element(concat(aws_rds_cluster.this.*.id, aws_rds_cluster.this-s3-restore.*.id), 0)
 }
 
 output "this_rds_cluster_resource_id" {
   description = "The Resource ID of the cluster"
-  value       = aws_rds_cluster.this.cluster_resource_id
+  value       = element(concat(aws_rds_cluster.this.*.cluster_resource_id, aws_rds_cluster.this-s3-restore.*.cluster_resource_id), 0)
 }
 
 output "this_rds_cluster_endpoint" {
   description = "The cluster endpoint"
-  value       = aws_rds_cluster.this.endpoint
+  value       = element(concat(aws_rds_cluster.this.*.endpoint, aws_rds_cluster.this-s3-restore.*.endpoint), 0)
 }
 
 output "this_rds_cluster_reader_endpoint" {
   description = "The cluster reader endpoint"
-  value       = aws_rds_cluster.this.reader_endpoint
+  value       = element(concat(aws_rds_cluster.this.*.reader_endpoint, aws_rds_cluster.this-s3-restore.*.reader_endpoint), 0)
 }
 
 // database_name is not set on `aws_rds_cluster` resource if it was not specified, so can't be used in output
@@ -32,18 +32,18 @@ output "this_rds_cluster_database_name" {
 
 output "this_rds_cluster_master_password" {
   description = "The master password"
-  value       = aws_rds_cluster.this.master_password
+  value       = element(concat(aws_rds_cluster.this.*.master_password, aws_rds_cluster.this-s3-restore.*.master_password), 0)
   sensitive   = true
 }
 
 output "this_rds_cluster_port" {
   description = "The port"
-  value       = aws_rds_cluster.this.port
+  value       = element(concat(aws_rds_cluster.this.*.port, aws_rds_cluster.this-s3-restore.*.port), 0)
 }
 
 output "this_rds_cluster_master_username" {
   description = "The master username"
-  value       = aws_rds_cluster.this.master_username
+  value       = element(concat(aws_rds_cluster.this.*.master_username, aws_rds_cluster.this-s3-restore.*.master_username), 0)
 }
 
 // aws_rds_cluster_instance

--- a/variables.tf
+++ b/variables.tf
@@ -320,3 +320,33 @@ variable "ca_cert_identifier" {
   type        = string
   default     = "rds-ca-2019"
 }
+
+variable "s3_import_bucket_name" {
+  description = "(Optional) The name of the S3 bucket to restore the database from"
+  type        = string
+  default     = ""
+}
+
+variable "s3_import_bucket_prefix" {
+  description = "(Optional) Can be blank, but is the path in s3 to your backup"
+  type        = string
+  default     = ""
+}
+
+variable "s3_import_ingestion_role" {
+  description = "Role applied to load the data from s3"
+  type        = string
+  default     = ""
+}
+
+variable "s3_import_source_engine" {
+  description = "Source engine for the backup. The only value accepted currently is: mysql"
+  type        = string
+  default     = "mysql"
+}
+
+variable "s3_import_source_engine_version" {
+  description = "Source engine version for the backup. The only value accepted currently is: mysql"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION

## Description
RDS Aurora allows you to import your database backup from a S3 bucket at creation time. I've added code, documentation & example on leveraging an existing database backup in S3 to create your Aurora RDS database.

## Motivation and Context
When migrating your databases from on-prem to the cloud as well as when using percona backup to backup your existing cloud database, using the 'Import from S3' option allows you to quickly setup a copy of your database. I was working on a use case that required the use of terraform for creating an Aurora RDS cluster and importing from a backup in S3. This functionality seemed to be missing from the terraform module, so, I wanted to contribute and add the functionality in.

## Breaking Changes
No

## How Has This Been Tested?
After being code complete, I ran multiple tests. They are as follows:
- Created an Aurora Postgres database using the Terraform module. It worked great. The important thing to keep in mind is that the S3 import functionality is only available for MySQL databases today.
- Created an Aurora MySQL cluster without the S3 import option. Worked as expected.
- Created an Aurora MySQL cluster with the S3 import option enabled.  This worked as expected.
- Created example code (found in the ./examples/mysql-s3import/ folder). I executed the code and the database was stood up correctly using the backup in S3. 
