### PR TITLE
feat: Add customizable instance settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ module "db" {
 - [MySQL](examples/mysql): A simple example with VPC and MySQL cluster.
 - [Serverless](examples/serverless): Serverless PostgreSQL cluster.
 - [Advanced](examples/advanced): A PostgreSQL cluster with enhanced monitoring and autoscaling enabled.
+- [Custom Instance Settings](examples/custom_instance_settings): A PostgreSQL cluster with custom instance settings.
 
 ## Documentation
 
@@ -111,6 +112,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | iam\_database\_authentication\_enabled | Specifies whether IAM Database authentication should be enabled or not. Not all versions and instances are supported. Refer to the AWS documentation to see which versions are supported. | `bool` | `false` | no |
 | iam\_roles | A List of ARNs for the IAM roles to associate to the RDS Cluster. | `list(string)` | `[]` | no |
 | instance\_type | Instance type to use | `string` | n/a | yes |
+| instance\_parameters | Customized instance settings. Supported keys: instance\_name, instance\_type, instance\_promotion\_tier | `list(map(string))` | [] | no
 | kms\_key\_id | The ARN for the KMS encryption key if one is set to the cluster. | `string` | `""` | no |
 | monitoring\_interval | The interval (seconds) between points when Enhanced Monitoring metrics are collected | `number` | `0` | no |
 | name | Name given resources | `string` | n/a | yes |

--- a/examples/custom_instance_settings/main.tf
+++ b/examples/custom_instance_settings/main.tf
@@ -1,0 +1,80 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+######################################
+# Data sources to get VPC and subnets
+######################################
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnet_ids" "all" {
+  vpc_id = data.aws_vpc.default.id
+}
+
+#############
+# RDS Aurora
+#############
+module "aurora" {
+  source                          = "../../"
+  name                            = "aurora-example-postgresql"
+  engine                          = "aurora-postgresql"
+  engine_version                  = "11.6"
+  subnets                         = data.aws_subnet_ids.all.ids
+  vpc_id                          = data.aws_vpc.default.id
+  replica_count                   = 3
+  instance_type                   = "db.r5.large"
+  apply_immediately               = true
+  skip_final_snapshot             = true
+  db_parameter_group_name         = aws_db_parameter_group.aurora_db_postgres11_parameter_group.id
+  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.aurora_cluster_postgres11_parameter_group.id
+  //  enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
+  security_group_description = ""
+
+  instances_parameters = [
+    // List index should be equal to `replica_count`
+    // Omitted keys replaced by module defaults
+    {
+      instance_type           = "db.r5.2xlarge"
+    },
+    {
+      instance_type           = "db.r5.2xlarge"
+    },
+    {
+      instance_name           = "reporting"
+      instance_type           = "db.r5.large"
+      instance_promotion_tier = 15
+    }
+  ]
+}
+
+resource "aws_db_parameter_group" "aurora_db_postgres11_parameter_group" {
+  name        = "test-aurora-db-postgres11-parameter-group"
+  family      = "aurora-postgresql11"
+  description = "test-aurora-db-postgres11-parameter-group"
+}
+
+resource "aws_rds_cluster_parameter_group" "aurora_cluster_postgres11_parameter_group" {
+  name        = "test-aurora-postgres11-cluster-parameter-group"
+  family      = "aurora-postgresql11"
+  description = "test-aurora-postgres11-cluster-parameter-group"
+}
+
+############################
+# Example of security group
+############################
+resource "aws_security_group" "app_servers" {
+  name_prefix = "app-servers-"
+  description = "For application servers"
+  vpc_id      = data.aws_vpc.default.id
+}
+
+resource "aws_security_group_rule" "allow_access" {
+  type                     = "ingress"
+  from_port                = module.aurora.this_rds_cluster_port
+  to_port                  = module.aurora.this_rds_cluster_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.app_servers.id
+  security_group_id        = module.aurora.this_security_group_id
+}

--- a/examples/custom_instance_settings/outputs.tf
+++ b/examples/custom_instance_settings/outputs.tf
@@ -1,0 +1,54 @@
+// aws_rds_cluster
+output "this_rds_cluster_id" {
+  description = "The ID of the cluster"
+  value       = module.aurora.this_rds_cluster_id
+}
+
+output "this_rds_cluster_resource_id" {
+  description = "The Resource ID of the cluster"
+  value       = module.aurora.this_rds_cluster_resource_id
+}
+
+output "this_rds_cluster_endpoint" {
+  description = "The cluster endpoint"
+  value       = module.aurora.this_rds_cluster_endpoint
+}
+
+output "this_rds_cluster_reader_endpoint" {
+  description = "The cluster reader endpoint"
+  value       = module.aurora.this_rds_cluster_reader_endpoint
+}
+
+output "this_rds_cluster_database_name" {
+  description = "Name for an automatically created database on cluster creation"
+  value       = module.aurora.this_rds_cluster_database_name
+}
+
+output "this_rds_cluster_master_password" {
+  description = "The master password"
+  value       = module.aurora.this_rds_cluster_master_password
+  sensitive   = true
+}
+
+output "this_rds_cluster_port" {
+  description = "The port"
+  value       = module.aurora.this_rds_cluster_port
+}
+
+output "this_rds_cluster_master_username" {
+  description = "The master username"
+  value       = module.aurora.this_rds_cluster_master_username
+}
+
+// aws_rds_cluster_instance
+output "this_rds_cluster_instance_endpoints" {
+  description = "A list of all cluster instance endpoints"
+  value       = module.aurora.this_rds_cluster_instance_endpoints
+}
+
+// aws_security_group
+output "this_security_group_id" {
+  description = "The security group ID of the cluster"
+  value       = module.aurora.this_security_group_id
+}
+

--- a/main.tf
+++ b/main.tf
@@ -64,8 +64,7 @@ resource "aws_rds_cluster" "this" {
   enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
 
   dynamic "scaling_configuration" {
-    for_each = length(keys(var.scaling_configuration)) == 0 ? [] : [
-    var.scaling_configuration]
+    for_each = length(keys(var.scaling_configuration)) == 0 ? [] : [var.scaling_configuration]
 
     content {
       auto_pause               = lookup(scaling_configuration.value, "auto_pause", null)
@@ -82,11 +81,11 @@ resource "aws_rds_cluster" "this" {
 resource "aws_rds_cluster_instance" "this" {
   count = var.replica_scale_enabled ? var.replica_scale_min : var.replica_count
 
-  identifier                      = "${var.name}-${count.index + 1}"
+  identifier                      = length(var.instances_parameters) > count.index ? lookup(var.instances_parameters[count.index], "instance_name", "${var.name}-${count.index + 1}") : "${var.name}-${count.index + 1}"
   cluster_identifier              = aws_rds_cluster.this.id
   engine                          = var.engine
   engine_version                  = var.engine_version
-  instance_class                  = var.instance_type
+  instance_class                  = length(var.instances_parameters) > count.index ? lookup(var.instances_parameters[count.index], "instance_type", var.instance_type) : var.instance_type
   publicly_accessible             = var.publicly_accessible
   db_subnet_group_name            = local.db_subnet_group_name
   db_parameter_group_name         = var.db_parameter_group_name
@@ -95,7 +94,7 @@ resource "aws_rds_cluster_instance" "this" {
   monitoring_role_arn             = local.rds_enhanced_monitoring_arn
   monitoring_interval             = var.monitoring_interval
   auto_minor_version_upgrade      = var.auto_minor_version_upgrade
-  promotion_tier                  = count.index + 1
+  promotion_tier                  = length(var.instances_parameters) > count.index ? lookup(var.instances_parameters[count.index], "instance_promotion_tier", count.index + 1) : count.index + 1
   performance_insights_enabled    = var.performance_insights_enabled
   performance_insights_kms_key_id = var.performance_insights_kms_key_id
   ca_cert_identifier              = var.ca_cert_identifier

--- a/variables.tf
+++ b/variables.tf
@@ -320,3 +320,9 @@ variable "ca_cert_identifier" {
   type        = string
   default     = "rds-ca-2019"
 }
+
+variable "instances_parameters" {
+  description = "Individual settings for instances"
+  type        = list(map(string))
+  default     = []
+}


### PR DESCRIPTION
## Description
Inspired by #119. Added with readme, example and requested changes.

Allow setting individual parameters for cluster instances

## Motivation and Context
We needed to add additional read only replica, for reporting needs. Some small instance type was enough for this task, however module allows only to specify number of nodes which share same parameters. We also needed to customize instance name and failover priority - promotion_tier (we do not want to failover to small instance).

## Breaking Changes
Requires TF >= v0.12
It is 100% compatible with previous versions.
If you specify variable in a module call:

```hcl
replica_count = 3

instances_parameters = [
{
  instance_name = "db-a"
  instance_type = "db.r5.large"
  instance_promotion_tier = 1
},
{
  instance_name = "db-b"
  instance_type = "db.t3.medium"
  instance_promotion_tier = 10
},
{
  instance_promotion_tier = 15
}
]
```
Customised setting will be used if they are set. If settings are missing module will generate like in previous version name, promotion_tier and will use var.instance_type for all nodes.
## How Has This Been Tested?
Tested on our AWS Dev account.
Tested cases:

- create brand new cluster without instances_parameters set
- create brand new cluster with instances_parameters set
- adding instances_parameters to an existing cluster
- removing instances_parameters from an existing cluster