### PR TITLE
docs: Add "multimaster" to engine_mode docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | enable\_http\_endpoint | Whether or not to enable the Data API for a serverless Aurora database engine. | `bool` | `false` | no |
 | enabled\_cloudwatch\_logs\_exports | List of log types to export to cloudwatch | `list(string)` | `[]` | no |
 | engine | Aurora database engine type, currently aurora, aurora-mysql or aurora-postgresql | `string` | `"aurora"` | no |
-| engine\_mode | The database engine mode. Valid values: global, parallelquery, provisioned, serverless. | `string` | `"provisioned"` | no |
+| engine\_mode | The database engine mode. Valid values: global, parallelquery, provisioned, serverless, multimaster. | `string` | `"provisioned"` | no |
 | engine\_version | Aurora database engine version. | `string` | `"5.6.10a"` | no |
 | final\_snapshot\_identifier\_prefix | The prefix name to use when creating a final snapshot on cluster destroy, appends a random 8 digits to name to ensure it's unique too. | `string` | `"final"` | no |
 | global\_cluster\_identifier | The global cluster identifier specified on aws\_rds\_global\_cluster | `string` | `""` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -259,7 +259,7 @@ variable "global_cluster_identifier" {
 }
 
 variable "engine_mode" {
-  description = "The database engine mode. Valid values: global, parallelquery, provisioned, serverless."
+  description = "The database engine mode. Valid values: global, parallelquery, provisioned, serverless, multimaster."
   type        = string
   default     = "provisioned"
 }


### PR DESCRIPTION
## Description
Add support for "multimaster" clusters in documentation

## Motivation and Context
Needed to create a "multimaster" cluster

## Breaking Changes
None

## How Has This Been Tested?
Setting `engine_mode` to "multimaster" creates a new RDS Aurora cluster with multiple writer nodes (limitations applied by AWS on region/instance type/number of instances)