### PR TITLE
fix: Ignore instance engine version updates

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -100,6 +100,14 @@ resource "aws_rds_cluster_instance" "this" {
   performance_insights_kms_key_id = var.performance_insights_kms_key_id
   ca_cert_identifier              = var.ca_cert_identifier
 
+  # Updating engine version forces replacement of instances, and they shouldn't be replaced
+  # because cluster will update them if engine version is changed
+  lifecycle {
+    ignore_changes = [
+      engine_version
+    ]
+  }
+
   tags = var.tags
 }
 


### PR DESCRIPTION
## Description
Updating engine version forces replacement of instances, and they shouldn't be replaced, because cluster will update them if the engine version is changed.

## Motivation and Context
Fixes https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/118

## Breaking Changes
none

## How Has This Been Tested?
I tested this on multiple aurora clusters to upgrade MySQL engine version 2.07.1 -> 2.07.2.
