### PR TITLE
feat: Add tags to RDS enhanced monitoring IAM role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file.
 
 
 
+<a name="v2.19.0"></a>
+## [v2.19.0] - 2020-06-12
+
+- feat: add "this_rds_cluster_instance_ids" to module outputs ([#107](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/107))
+- docs: Add "multimaster" to engine_mode docs ([#133](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/133))
+
+
 <a name="v2.18.0"></a>
 ## [v2.18.0] - 2020-06-10
 
@@ -374,7 +381,8 @@ when calling import with this module in the configuration.
 - Initial commit
 
 
-[Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.18.0...HEAD
+[Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.19.0...HEAD
+[v2.19.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.18.0...v2.19.0
 [v2.18.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.17.0...v2.18.0
 [v2.17.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.16.0...v2.17.0
 [v2.16.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.15.0...v2.16.0

--- a/main.tf
+++ b/main.tf
@@ -129,6 +129,10 @@ resource "aws_iam_role" "rds_enhanced_monitoring" {
   assume_role_policy = data.aws_iam_policy_document.monitoring_rds_assume_role.json
 
   permissions_boundary = var.permissions_boundary
+  
+  tags = merge(var.tags, {
+    Name = local.name
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {


### PR DESCRIPTION
## Description
This PR adds tags to RDS enhanced monitoring IAM role. 

## Motivation and Context
The documentation says:
> tags: A map of tags to add to all resources.

But the tags are not added to the IAM role created for RDS enhanced monitoring. This PR fixes that.

## Breaking Changes
None.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
According to the [iam_role](https://www.terraform.io/docs/providers/aws/r/iam_role.html#tags) this should work.
