### PR TITLE
feat: Support the aws_rds_global_cluster resource for global clusters

### DIFF
--- a/examples/global/main.tf
+++ b/examples/global/main.tf
@@ -39,7 +39,7 @@ data "aws_subnet_ids" "ohio" {
 }
 
 data "aws_kms_key" "key" {
-  key_id = "alias/aws/rds"
+  key_id   = "alias/aws/rds"
   provider = aws.ohio
 }
 
@@ -54,6 +54,7 @@ module "virginia_aurora" {
   engine_mode               = "provisioned"
   subnets                   = data.aws_subnet_ids.virginia.ids
   vpc_id                    = data.aws_vpc.virginia.id
+  is_primary_region         = true
   replica_count             = 2
   instance_type             = "db.r5.large"
   apply_immediately         = true
@@ -67,21 +68,21 @@ module "virginia_aurora" {
 }
 
 module "ohio_aurora" {
-  source                    = "../../"
-  name                      = "aurora-example-global-ohio"
-  engine                    = "aurora-postgresql"
-  engine_version            = "11.7"
-  engine_mode               = "provisioned"
-  subnets                   = data.aws_subnet_ids.ohio.ids
-  vpc_id                    = data.aws_vpc.ohio.id
-  replica_count             = 2
-  instance_type             = "db.r5.large"
-  apply_immediately         = true
-  skip_final_snapshot       = true
+  source              = "../../"
+  name                = "aurora-example-global-ohio"
+  engine              = "aurora-postgresql"
+  engine_version      = "11.7"
+  engine_mode         = "provisioned"
+  subnets             = data.aws_subnet_ids.ohio.ids
+  vpc_id              = data.aws_vpc.ohio.id
+  replica_count       = 2
+  instance_type       = "db.r5.large"
+  apply_immediately   = true
+  skip_final_snapshot = true
 
-  create_global_cluster     = false
-  global_cluster_identifier = "aurora-example-global"
-  is_primary_region = false
+  create_global_cluster         = false
+  global_cluster_identifier     = module.virginia_aurora.this_rds_cluster_global_id
+  is_primary_region             = false
   kms_key_id                    = data.aws_kms_key.key.arn
   replication_source_identifier = module.virginia_aurora.this_rds_cluster_arn
   source_region                 = "us-east-1"

--- a/examples/global/main.tf
+++ b/examples/global/main.tf
@@ -1,0 +1,92 @@
+provider "aws" {
+  alias  = "virginia"
+  region = "us-east-1"
+}
+
+provider "aws" {
+  alias  = "ohio"
+  region = "us-east-2"
+}
+
+# aws_rds_global_cluster added support for postgres in v2.57.0
+terraform {
+  required_providers {
+    aws = ">= 2.57.0, < 4.0"
+  }
+}
+
+#######################################################
+# Data sources to get VPC, subnets, and encryption key
+#######################################################
+data "aws_vpc" "virginia" {
+  default  = true
+  provider = aws.virginia
+}
+
+data "aws_subnet_ids" "virginia" {
+  vpc_id   = data.aws_vpc.virginia.id
+  provider = aws.virginia
+}
+
+data "aws_vpc" "ohio" {
+  default  = true
+  provider = aws.ohio
+}
+
+data "aws_subnet_ids" "ohio" {
+  vpc_id   = data.aws_vpc.ohio.id
+  provider = aws.ohio
+}
+
+data "aws_kms_key" "key" {
+  key_id = "alias/aws/rds"
+  provider = aws.ohio
+}
+
+#####################
+# RDS Aurora Cluster
+#####################
+module "virginia_aurora" {
+  source                    = "../../"
+  name                      = "aurora-example-global-virginia"
+  engine                    = "aurora-postgresql"
+  engine_version            = "11.7"
+  engine_mode               = "provisioned"
+  subnets                   = data.aws_subnet_ids.virginia.ids
+  vpc_id                    = data.aws_vpc.virginia.id
+  replica_count             = 2
+  instance_type             = "db.r5.large"
+  apply_immediately         = true
+  skip_final_snapshot       = true
+  create_global_cluster     = true
+  global_cluster_identifier = "aurora-example-global"
+
+  providers = {
+    aws = aws.virginia
+  }
+}
+
+module "ohio_aurora" {
+  source                    = "../../"
+  name                      = "aurora-example-global-ohio"
+  engine                    = "aurora-postgresql"
+  engine_version            = "11.7"
+  engine_mode               = "provisioned"
+  subnets                   = data.aws_subnet_ids.ohio.ids
+  vpc_id                    = data.aws_vpc.ohio.id
+  replica_count             = 2
+  instance_type             = "db.r5.large"
+  apply_immediately         = true
+  skip_final_snapshot       = true
+
+  create_global_cluster     = false
+  global_cluster_identifier = "aurora-example-global"
+  is_primary_region = false
+  kms_key_id                    = data.aws_kms_key.key.arn
+  replication_source_identifier = module.virginia_aurora.this_rds_cluster_arn
+  source_region                 = "us-east-1"
+
+  providers = {
+    aws = aws.ohio
+  }
+}

--- a/examples/global/outputs.tf
+++ b/examples/global/outputs.tf
@@ -16,7 +16,7 @@ output "this_rds_cluster_endpoint" {
 
 output "this_rds_cluster_reader_endpoints" {
   description = "The cluster reader endpoint"
-  value       = [
+  value = [
     module.virginia_aurora.this_rds_cluster_reader_endpoint,
     module.ohio_aurora.this_rds_cluster_reader_endpoint,
   ]
@@ -46,7 +46,7 @@ output "this_rds_cluster_master_username" {
 // aws_rds_cluster_instance
 output "this_rds_cluster_instance_endpoints" {
   description = "A list of all cluster instance endpoints"
-  value       = concat(
+  value = concat(
     module.virginia_aurora.this_rds_cluster_instance_endpoints,
     module.ohio_aurora.this_rds_cluster_instance_endpoints,
   )
@@ -54,7 +54,7 @@ output "this_rds_cluster_instance_endpoints" {
 
 output "this_rds_cluster_instance_ids" {
   description = "A list of all cluster instance ids"
-  value       = concat(
+  value = concat(
     module.virginia_aurora.this_rds_cluster_instance_ids,
     module.ohio_aurora.this_rds_cluster_instance_ids,
   )

--- a/examples/global/outputs.tf
+++ b/examples/global/outputs.tf
@@ -1,0 +1,67 @@
+// aws_rds_cluster
+output "this_rds_cluster_id" {
+  description = "The ID of the primary cluster"
+  value       = module.virginia_aurora.this_rds_cluster_id
+}
+
+output "this_rds_cluster_resource_id" {
+  description = "The Resource ID of the primary cluster"
+  value       = module.virginia_aurora.this_rds_cluster_resource_id
+}
+
+output "this_rds_cluster_endpoint" {
+  description = "The cluster endpoint"
+  value       = module.virginia_aurora.this_rds_cluster_endpoint
+}
+
+output "this_rds_cluster_reader_endpoints" {
+  description = "The cluster reader endpoint"
+  value       = [
+    module.virginia_aurora.this_rds_cluster_reader_endpoint,
+    module.ohio_aurora.this_rds_cluster_reader_endpoint,
+  ]
+}
+
+output "this_rds_cluster_database_name" {
+  description = "Name for an automatically created database on cluster creation"
+  value       = module.virginia_aurora.this_rds_cluster_database_name
+}
+
+output "this_rds_cluster_master_password" {
+  description = "The master password"
+  value       = module.virginia_aurora.this_rds_cluster_master_password
+  sensitive   = true
+}
+
+output "this_rds_cluster_port" {
+  description = "The port"
+  value       = module.virginia_aurora.this_rds_cluster_port
+}
+
+output "this_rds_cluster_master_username" {
+  description = "The master username"
+  value       = module.virginia_aurora.this_rds_cluster_master_username
+}
+
+// aws_rds_cluster_instance
+output "this_rds_cluster_instance_endpoints" {
+  description = "A list of all cluster instance endpoints"
+  value       = concat(
+    module.virginia_aurora.this_rds_cluster_instance_endpoints,
+    module.ohio_aurora.this_rds_cluster_instance_endpoints,
+  )
+}
+
+output "this_rds_cluster_instance_ids" {
+  description = "A list of all cluster instance ids"
+  value       = concat(
+    module.virginia_aurora.this_rds_cluster_instance_ids,
+    module.ohio_aurora.this_rds_cluster_instance_ids,
+  )
+}
+
+// aws_security_group
+output "this_security_group_id" {
+  description = "The security group ID of the primary cluster"
+  value       = module.virginia_aurora.this_security_group_id
+}

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   port                 = var.port == "" ? var.engine == "aurora-postgresql" ? "5432" : "3306" : var.port
-  master_password      = var.password == "" ? element(concat(random_password.master_password.*.result, [""]), 0) : var.password
+  master_password      = var.replication_source_identifier == "" ? (var.password == "" ? element(concat(random_password.master_password.*.result, [""]), 0) : var.password) : ""
   db_subnet_group_name = var.db_subnet_group_name == "" ? join("", aws_db_subnet_group.this.*.name) : var.db_subnet_group_name
   backtrack_window     = (var.engine == "aurora-mysql" || var.engine == "aurora") && var.engine_mode != "serverless" ? var.backtrack_window : 0
 

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,7 @@ resource "aws_rds_global_cluster" "this" {
   engine                    = var.engine
   engine_version            = var.engine_version
   storage_encrypted         = var.storage_encrypted
+  source_db_cluster_identifier = try(aws_rds_cluster.this[0].id, "")
 }
 
 resource "aws_db_subnet_group" "this" {
@@ -46,7 +47,6 @@ resource "aws_db_subnet_group" "this" {
 resource "aws_rds_cluster" "this" {
   count = var.create_cluster ? 1 : 0
 
-  global_cluster_identifier           = try(aws_rds_global_cluster.this[0].id, "")
   cluster_identifier                  = var.name
   replication_source_identifier       = var.replication_source_identifier
   source_region                       = var.source_region

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   port                 = var.port == "" ? var.engine == "aurora-postgresql" ? "5432" : "3306" : var.port
   master_username      = var.is_primary_region ? var.username : ""
-  master_password      = var.is_primary_region == "" ? (var.password == "" ? element(concat(random_password.master_password.*.result, [""]), 0) : var.password) : ""
+  master_password      = var.is_primary_region ? (var.password == "" ? element(concat(random_password.master_password.*.result, [""]), 0) : var.password) : ""
   db_subnet_group_name = var.db_subnet_group_name == "" ? join("", aws_db_subnet_group.this.*.name) : var.db_subnet_group_name
   backtrack_window     = (var.engine == "aurora-mysql" || var.engine == "aurora") && var.engine_mode != "serverless" ? var.backtrack_window : 0
 

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "random_password" "master_password" {
   special = false
 }
 
-resource "aws_rds_global_cluster" "global_cluster" {
+resource "aws_rds_global_cluster" "this" {
   count                     = var.create_global_cluster ? 1 : 0
   global_cluster_identifier = var.global_cluster_identifier
 }
@@ -85,7 +85,8 @@ resource "aws_rds_cluster" "this" {
     }
   }
 
-  tags = var.tags
+  depends_on = [aws_rds_global_cluster.this]
+  tags       = var.tags
 }
 
 resource "aws_rds_cluster_instance" "this" {

--- a/main.tf
+++ b/main.tf
@@ -22,14 +22,15 @@ resource "random_password" "master_password" {
 }
 
 resource "aws_rds_global_cluster" "this" {
-  count                     = var.create_global_cluster ? 1 : 0
-  global_cluster_identifier = var.global_cluster_identifier
-  database_name             = var.database_name
-  deletion_protection       = var.deletion_protection
-  engine                    = var.engine
-  engine_version            = var.engine_version
-  storage_encrypted         = var.storage_encrypted
+  count                        = var.create_global_cluster ? 1 : 0
+  global_cluster_identifier    = var.global_cluster_identifier
+  database_name                = var.database_name
+  deletion_protection          = var.deletion_protection
+  engine                       = var.engine
+  engine_version               = var.engine_version
+  storage_encrypted            = var.storage_encrypted
   source_db_cluster_identifier = try(aws_rds_cluster.this[0].id, "")
+  force_destroy                = false
 }
 
 resource "aws_db_subnet_group" "this" {
@@ -90,7 +91,7 @@ resource "aws_rds_cluster" "this" {
     }
   }
 
-  tags       = var.tags
+  tags = var.tags
 }
 
 resource "aws_rds_cluster_instance" "this" {

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   port                 = var.port == "" ? var.engine == "aurora-postgresql" ? "5432" : "3306" : var.port
-  master_username      = var.replication_source_identifier == "" ? var.username : ""
-  master_password      = var.replication_source_identifier == "" ? (var.password == "" ? element(concat(random_password.master_password.*.result, [""]), 0) : var.password) : ""
+  master_username      = var.is_primary_region ? var.username : ""
+  master_password      = var.is_primary_region == "" ? (var.password == "" ? element(concat(random_password.master_password.*.result, [""]), 0) : var.password) : ""
   db_subnet_group_name = var.db_subnet_group_name == "" ? join("", aws_db_subnet_group.this.*.name) : var.db_subnet_group_name
   backtrack_window     = (var.engine == "aurora-mysql" || var.engine == "aurora") && var.engine_mode != "serverless" ? var.backtrack_window : 0
 

--- a/main.tf
+++ b/main.tf
@@ -24,11 +24,7 @@ resource "random_password" "master_password" {
 resource "aws_rds_global_cluster" "this" {
   count                        = var.create_global_cluster ? 1 : 0
   global_cluster_identifier    = var.global_cluster_identifier
-  database_name                = var.database_name
   deletion_protection          = var.deletion_protection
-  engine                       = var.engine
-  engine_version               = var.engine_version
-  storage_encrypted            = var.storage_encrypted
   source_db_cluster_identifier = try(aws_rds_cluster.this[0].id, "")
   force_destroy                = false
 }

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "aws_rds_global_cluster" "this" {
   count                        = var.create_global_cluster ? 1 : 0
   global_cluster_identifier    = var.global_cluster_identifier
   deletion_protection          = var.deletion_protection
-  source_db_cluster_identifier = try(aws_rds_cluster.this[0].id, "")
+  source_db_cluster_identifier = try(aws_rds_cluster.this[0].arn, "")
   force_destroy                = false
 }
 

--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,11 @@ resource "random_password" "master_password" {
 resource "aws_rds_global_cluster" "this" {
   count                     = var.create_global_cluster ? 1 : 0
   global_cluster_identifier = var.global_cluster_identifier
+  database_name             = var.database_name
+  deletion_protection       = var.deletion_protection
+  engine                    = var.engine
+  engine_version            = var.engine_version
+  storage_encrypted         = var.storage_encrypted
 }
 
 resource "aws_db_subnet_group" "this" {

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "aws_db_subnet_group" "this" {
 resource "aws_rds_cluster" "this" {
   count = var.create_cluster ? 1 : 0
 
-  global_cluster_identifier           = try(aws_rds_global_cluster.this[0].global_cluster_identifier, "")
+  global_cluster_identifier           = try(aws_rds_global_cluster.this[0].id, "")
   cluster_identifier                  = var.name
   replication_source_identifier       = var.replication_source_identifier
   source_region                       = var.source_region

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "aws_db_subnet_group" "this" {
 resource "aws_rds_cluster" "this" {
   count = var.create_cluster ? 1 : 0
 
-  global_cluster_identifier           = var.global_cluster_identifier
+  global_cluster_identifier           = try(aws_rds_global_cluster.this[0].global_cluster_identifier, "")
   cluster_identifier                  = var.name
   replication_source_identifier       = var.replication_source_identifier
   source_region                       = var.source_region

--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,6 @@ resource "aws_rds_cluster" "this" {
     }
   }
 
-  depends_on = [aws_rds_global_cluster.this]
   tags       = var.tags
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,6 +9,11 @@ output "this_rds_cluster_id" {
   value       = element(concat(aws_rds_cluster.this.*.id, [""]), 0)
 }
 
+output "this_rds_cluster_global_id" {
+  description = "The ID of the global cluster. Only present if this is the primary subcluster"
+  value = element(concat(aws_rds_global_cluster.this.*.id, [""]), 0)
+}
+
 output "this_rds_cluster_resource_id" {
   description = "The Resource ID of the cluster"
   value       = element(concat(aws_rds_cluster.this.*.cluster_resource_id, [""]), 0)

--- a/variables.tf
+++ b/variables.tf
@@ -280,6 +280,12 @@ variable "enabled_cloudwatch_logs_exports" {
   default     = []
 }
 
+variable "create_global_cluster" {
+  description = "Whether to create a global cluster or not. If true, the cluster will be named var.global_cluster_identifier"
+  type        = bool
+  default     = false
+}
+
 variable "global_cluster_identifier" {
   description = "The global cluster identifier specified on aws_rds_global_cluster"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -280,6 +280,12 @@ variable "enabled_cloudwatch_logs_exports" {
   default     = []
 }
 
+variable "is_primary_region" {
+  description = "False when this is either a cross-region replica database, or is a secondary region in a global table"
+  type        = bool
+  default     = true
+}
+
 variable "create_global_cluster" {
   description = "Whether to create a global cluster or not. If true, the cluster will be named var.global_cluster_identifier"
   type        = bool


### PR DESCRIPTION
## Description
This allows the creation of globally clusters entirely using this module. To do so, one would have one module use `create_global_cluster = true`, and then the other reference the cluster id from the primary region

var.username and var.password are now ignored when a new variable `is_primary_region` is false. This is because cross-region read replicas cannot specify usernames or passwords, but this module previously made that impossible to do by using a random password if the `password` variable was given as empty.

## How Has This Been Tested?
I have created modules with this change.
