### PR TITLE
feat: Allows override of instance identifier (#143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
-
+- feat: Allows override of instance identifier ([#143](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/143))
 
 <a name="v2.23.0"></a>
 ## [v2.23.0] - 2020-08-27

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,8 @@ locals {
   db_subnet_group_name = var.db_subnet_group_name == "" ? join("", aws_db_subnet_group.this.*.name) : var.db_subnet_group_name
   backtrack_window     = (var.engine == "aurora-mysql" || var.engine == "aurora") && var.engine_mode != "serverless" ? var.backtrack_window : 0
 
+  db_instance_identifier = var.instance_identifier == "" ? var.name : var.instance_identifier
+
   rds_enhanced_monitoring_arn  = join("", aws_iam_role.rds_enhanced_monitoring.*.arn)
   rds_enhanced_monitoring_name = join("", aws_iam_role.rds_enhanced_monitoring.*.name)
 
@@ -82,7 +84,7 @@ resource "aws_rds_cluster" "this" {
 resource "aws_rds_cluster_instance" "this" {
   count = var.replica_scale_enabled ? var.replica_scale_min : var.replica_count
 
-  identifier                      = "${var.name}-${count.index + 1}"
+  identifier                      = "${local.db_instance_identifier}-${count.index + 1}"
   cluster_identifier              = aws_rds_cluster.this.id
   engine                          = var.engine
   engine_version                  = var.engine_version

--- a/variables.tf
+++ b/variables.tf
@@ -48,6 +48,12 @@ variable "instance_type" {
   type        = string
 }
 
+variable "instance_identifier" {
+  description = "Identifier for any instances created.  This will be suffixed with '-<index+1>'. If instance_identifier is not set, it will use var.name value"
+  type        = string
+  default     = ""
+}
+
 variable "publicly_accessible" {
   description = "Whether the DB should have a public IP address"
   type        = bool


### PR DESCRIPTION
## Description
Adds a new optional variable `instance_identifier` to allow for conditional override of the instance identifier attribute.  

## Motivation and Context
If your `var.name` parameter is 62 characters, when the instance identifier adds a suffix of `-1`, it will hit the 64 character limit of the instance, even though the cluster was created without issue. #143 

Normally, no sane person would create a 62 character cluster name, but we are importing resources that were auto-named by CloudFormation, which seemingly has no qualms making a very long cluster name.

## Breaking Changes
This change is fully backwards compatible.  By default, the `instance_identifier` is `""`, and will use the `var.name` variable.  If `instance_identifier` is provided, it will use that instead.

## How Has This Been Tested?
We applied this against our systems:
```
# Fails, Instance identifier is `production-rds-aurora-0123456789012345678901234567890123456789-1`; 64 characters; one-too-many
module "aurora" {
  source  = "terraform-aws-modules/rds-aurora/aws"
  version = "~> 2.0"

  name = "production-rds-aurora-0123456789012345678901234567890123456789" # 62 characters
  # [...]
}

# Works!  Instance identifier is `production-rds-aurora-1`
module "aurora_fix" {
  source  = "github.com/ussba/terraform-aws-rds-aurora?ref=add-instance-id-override"

  name = "production-rds-aurora-0123456789012345678901234567890123456789" # 62 characters
  instance_identifier = "production-rds-aurora"
  # [...]
}
```
