### PR TITLE
feat: Allow to customizable instance settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 
 
 
+<a name="v2.23.0"></a>
+## [v2.23.0] - 2020-08-27
+
+- feat: Allows different instance_size for replicas ([#61](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/61))
+
+
 <a name="v2.22.0"></a>
 ## [v2.22.0] - 2020-08-19
 
@@ -400,7 +406,8 @@ when calling import with this module in the configuration.
 - Initial commit
 
 
-[Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.22.0...HEAD
+[Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.23.0...HEAD
+[v2.23.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.22.0...v2.23.0
 [v2.22.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.21.0...v2.22.0
 [v2.21.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.20.0...v2.21.0
 [v2.20.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.19.0...v2.20.0

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | iam\_roles | A List of ARNs for the IAM roles to associate to the RDS Cluster. | `list(string)` | `[]` | no |
 | instance\_type | Instance type to use at master instance. If instance\_type\_replica is not set it will use the same type for replica instances | `string` | n/a | yes |
 | instance\_type\_replica | Instance type to use at replica instance | `string` | `null` | no |
-| instance\_parameters | Customized instance settings. Supported keys: instance\_name, instance\_type, instance\_promotion\_tier | `list(map(string))` | [] | no
+| instance\_parameters | Customized instance settings. Supported keys: instance\_name, instance\_type, instance\_promotion\_tier | publicly\_accessible | `list(map(string))` | [] | no
 | kms\_key\_id | The ARN for the KMS encryption key if one is set to the cluster. | `string` | `""` | no |
 | monitoring\_interval | The interval (seconds) between points when Enhanced Monitoring metrics are collected | `number` | `0` | no |
 | name | Name given resources | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | iam\_roles | A List of ARNs for the IAM roles to associate to the RDS Cluster. | `list(string)` | `[]` | no |
 | instance\_type | Instance type to use at master instance. If instance\_type\_replica is not set it will use the same type for replica instances | `string` | n/a | yes |
 | instance\_type\_replica | Instance type to use at replica instance | `string` | `null` | no |
-| instance\_parameters | Customized instance settings. Supported keys: instance\_name, instance\_type, instance\_promotion\_tier | publicly\_accessible | `list(map(string))` | [] | no
+| instances\_parameters | Customized instance settings. Supported keys: instance\_name, instance\_type, instance\_promotion\_tier, publicly\_accessible | `list(map(string))` | `[]` | no |
 | kms\_key\_id | The ARN for the KMS encryption key if one is set to the cluster. | `string` | `""` | no |
 | monitoring\_interval | The interval (seconds) between points when Enhanced Monitoring metrics are collected | `number` | `0` | no |
 | monitoring\_role\_arn | IAM role for RDS to send enhanced monitoring metrics to CloudWatch | `string` | `""` | no |

--- a/examples/custom_instance_settings/main.tf
+++ b/examples/custom_instance_settings/main.tf
@@ -37,6 +37,7 @@ module "aurora" {
     // Omitted keys replaced by module defaults
     {
       instance_type           = "db.r5.2xlarge"
+      publicly_accessible     = true
     },
     {
       instance_type           = "db.r5.2xlarge"

--- a/examples/custom_instance_settings/main.tf
+++ b/examples/custom_instance_settings/main.tf
@@ -36,11 +36,11 @@ module "aurora" {
     // List index should be equal to `replica_count`
     // Omitted keys replaced by module defaults
     {
-      instance_type           = "db.r5.2xlarge"
-      publicly_accessible     = true
+      instance_type       = "db.r5.2xlarge"
+      publicly_accessible = true
     },
     {
-      instance_type           = "db.r5.2xlarge"
+      instance_type = "db.r5.2xlarge"
     },
     {
       instance_name           = "reporting"

--- a/main.tf
+++ b/main.tf
@@ -86,7 +86,7 @@ resource "aws_rds_cluster_instance" "this" {
   engine                          = var.engine
   engine_version                  = var.engine_version
   instance_class                  = length(var.instances_parameters) > count.index ? lookup(var.instances_parameters[count.index], "instance_type", var.instance_type) : count.index > 0 ? coalesce(var.instance_type_replica, var.instance_type) : var.instance_type
-  publicly_accessible             = var.publicly_accessible
+  publicly_accessible             = length(var.instances_parameters) > count.index ? lookup(var.instances_parameters[count.index], "publicly_accessible", var.publicly_accessible) : var.publicly_accessible
   db_subnet_group_name            = local.db_subnet_group_name
   db_parameter_group_name         = var.db_parameter_group_name
   preferred_maintenance_window    = var.preferred_maintenance_window

--- a/variables.tf
+++ b/variables.tf
@@ -346,7 +346,7 @@ variable "ca_cert_identifier" {
 }
 
 variable "instances_parameters" {
-  description = "Individual settings for instances"
+  description = "Customized instance settings. Supported keys: instance_name, instance_type, instance_promotion_tier, publicly_accessible"
   type        = list(map(string))
   default     = []
 }


### PR DESCRIPTION
## Description
Extend PR #132 to allow publicly setting can be set per instance

## Motivation and Context
Sometimes cluster instances can be hidden from public access (let's say writer is private but readers are not), I've combined changes from PR #132 and extend them to control **publicly_accessible** setting per instance.

## Breaking Changes
Doesn't change current setup, old configuration syntax still supported. 

## How Has This Been Tested?
This code from provided example works:
`  instances_parameters = [
    // List index should be equal to `replica_count`
    // Omitted keys replaced by module defaults
    {
      instance_type           = "db.r5.2xlarge"
      publicly_accessible     = true
    },
    {
      instance_type           = "db.r5.2xlarge"
    },
    {
      instance_name           = "reporting"
      instance_type           = "db.r5.large"
      instance_promotion_tier = 15
    }
  ]
`