### PR TITLE
fix: Set replica_count to 1 in example for mysql

### DIFF
--- a/examples/mysql/main.tf
+++ b/examples/mysql/main.tf
@@ -23,7 +23,7 @@ module "aurora" {
   engine_version                      = "5.7.12"
   subnets                             = data.aws_subnet_ids.all.ids
   vpc_id                              = data.aws_vpc.default.id
-  replica_count                       = 0
+  replica_count                       = 1
   instance_type                       = "db.t2.medium"
   apply_immediately                   = true
   skip_final_snapshot                 = true


### PR DESCRIPTION
## Description
Change replica_count to 1 for the mysql example so that you can get actual instances and not an empty provisioned cluster.

## Motivation and Context
If replica_count is set to 0 you end up with a cluster with no instances
and no way clear way of rectifying it via the console. Setting it to 1 makes it at least work when people copy paste.

## Breaking Changes
Nope.

## How Has This Been Tested?
It's an example that actually works now and hopefully results in less troubleshooting/head scratching to figure it out. As I read replica_count as being replicas of the main instance not how many instances I wanted total etc.
