### PR TITLE
feat: add output engine_version to force provider order

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | this\_rds\_cluster\_arn | The ID of the cluster |
 | this\_rds\_cluster\_database\_name | Name for an automatically created database on cluster creation |
 | this\_rds\_cluster\_endpoint | The cluster endpoint |
-| this\_rds\_cluster\_engine_version | The computed engine version |
+| this\_rds\_cluster\_engine_version | The cluster engine version |
 | this\_rds\_cluster\_hosted\_zone\_id | Route53 hosted zone id of the created cluster |
 | this\_rds\_cluster\_id | The ID of the cluster |
 | this\_rds\_cluster\_instance\_endpoints | A list of all cluster instance endpoints |

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | this\_rds\_cluster\_arn | The ID of the cluster |
 | this\_rds\_cluster\_database\_name | Name for an automatically created database on cluster creation |
 | this\_rds\_cluster\_endpoint | The cluster endpoint |
+| this\_rds\_cluster\_engine_version | The computed engine version |
 | this\_rds\_cluster\_hosted\_zone\_id | Route53 hosted zone id of the created cluster |
 | this\_rds\_cluster\_id | The ID of the cluster |
 | this\_rds\_cluster\_instance\_endpoints | A list of all cluster instance endpoints |

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,6 +19,11 @@ output "this_rds_cluster_endpoint" {
   value       = aws_rds_cluster.this.endpoint
 }
 
+output "this_rds_cluster_engine_version" {
+  description = "The cluster engine version"
+  value       = aws_rds_cluster.this.engine_version
+}
+
 output "this_rds_cluster_reader_endpoint" {
   description = "The cluster reader endpoint"
   value       = aws_rds_cluster.this.reader_endpoint


### PR DESCRIPTION
## Description
I have added the engine_version output

## Motivation and Context
context; https://github.com/terraform-providers/terraform-provider-postgresql/issues/2#issuecomment-567887609
<!--- Why is this change required? What problem does it solve? -->
This is a helper to the postgres provider, to use its mechanics so there is a way you can instantiate your Aurora postgres instance and use the postgres provider in one run/plan.

<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No Breaking changes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested it in my code base, plans now succeed even though the RDS has not been created yet.
