### PR TITLE
feat: Added conditional creation of RDS Aurora cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 
 
 
+<a name="v2.29.0"></a>
+## [v2.29.0] - 2020-10-30
+
+- feat: Added conditional creation of RDS Aurora cluster ([#159](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/159))
+
+
 <a name="v2.28.0"></a>
 ## [v2.28.0] - 2020-10-13
 
@@ -437,7 +443,8 @@ when calling import with this module in the configuration.
 - Initial commit
 
 
-[Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.28.0...HEAD
+[Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.29.0...HEAD
+[v2.29.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.28.0...v2.29.0
 [v2.28.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.27.0...v2.28.0
 [v2.27.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.26.0...v2.27.0
 [v2.26.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.25.0...v2.26.0

--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ module "db" {
 }
 ```
 
+## Conditional creation
+
+Sometimes you need to have a way to create RDS Aurora resources conditionally but Terraform does not allow to use `count` inside `module` block, so the solution is to specify argument `create_cluster`.
+
+```hcl
+# This RDS cluster will not be created
+module "db" {
+  source  = "terraform-aws-modules/rds-aurora/aws"
+  version = "~> 2.0"
+
+  create_cluster = false
+  # ... omitted
+}
+```
+
 ## Examples
 
 - [PostgreSQL](examples/postgresql): A simple example with VPC and PostgreSQL cluster.
@@ -73,16 +88,16 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6, < 0.14 |
-| aws | >= 2.45, < 4.0 |
-| random | ~> 2.2 |
+| terraform | >= 0.12.6 |
+| aws | >= 2.45 |
+| random | >= 2.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.45, < 4.0 |
-| random | ~> 2.2 |
+| aws | >= 2.45 |
+| random | >= 2.2 |
 
 ## Inputs
 
@@ -96,6 +111,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | backup\_retention\_period | How long to keep backups for (in days) | `number` | `7` | no |
 | ca\_cert\_identifier | The identifier of the CA certificate for the DB instance | `string` | `"rds-ca-2019"` | no |
 | copy\_tags\_to\_snapshot | Copy all Cluster tags to snapshots. | `bool` | `false` | no |
+| create\_cluster | Controls if RDS cluster should be created (it affects almost all resources) | `bool` | `true` | no |
 | create\_monitoring\_role | Whether to create the IAM role for RDS enhanced monitoring | `bool` | `true` | no |
 | create\_security\_group | Whether to create security group for RDS cluster | `bool` | `true` | no |
 | database\_name | Name for an automatically created database on cluster creation | `string` | `""` | no |
@@ -112,13 +128,13 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | global\_cluster\_identifier | The global cluster identifier specified on aws\_rds\_global\_cluster | `string` | `""` | no |
 | iam\_database\_authentication\_enabled | Specifies whether IAM Database authentication should be enabled or not. Not all versions and instances are supported. Refer to the AWS documentation to see which versions are supported. | `bool` | `false` | no |
 | iam\_roles | A List of ARNs for the IAM roles to associate to the RDS Cluster. | `list(string)` | `[]` | no |
-| instance\_type | Instance type to use at master instance. If instance\_type\_replica is not set it will use the same type for replica instances | `string` | n/a | yes |
+| instance\_type | Instance type to use at master instance. If instance\_type\_replica is not set it will use the same type for replica instances | `string` | `""` | no |
 | instance\_type\_replica | Instance type to use at replica instance | `string` | `null` | no |
 | instances\_parameters | Customized instance settings. Supported keys: instance\_name, instance\_type, instance\_promotion\_tier, publicly\_accessible | `list(map(string))` | `[]` | no |
 | kms\_key\_id | The ARN for the KMS encryption key if one is set to the cluster. | `string` | `""` | no |
 | monitoring\_interval | The interval (seconds) between points when Enhanced Monitoring metrics are collected | `number` | `0` | no |
 | monitoring\_role\_arn | IAM role for RDS to send enhanced monitoring metrics to CloudWatch | `string` | `""` | no |
-| name | Name given resources | `string` | n/a | yes |
+| name | Name given resources | `string` | `""` | no |
 | password | Master DB password | `string` | `""` | no |
 | performance\_insights\_enabled | Specifies whether Performance Insights is enabled or not. | `bool` | `false` | no |
 | performance\_insights\_kms\_key\_id | The ARN for the KMS key to encrypt Performance Insights data. | `string` | `""` | no |
@@ -146,7 +162,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | subnets | List of subnet IDs to use | `list(string)` | `[]` | no |
 | tags | A map of tags to add to all resources. | `map(string)` | `{}` | no |
 | username | Master DB username | `string` | `"root"` | no |
-| vpc\_id | VPC ID | `string` | n/a | yes |
+| vpc\_id | VPC ID | `string` | `""` | no |
 | vpc\_security\_group\_ids | List of VPC security groups to associate to the cluster in addition to the SG we create in this module | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = ">= 0.12.6, < 0.14"
+  required_version = ">= 0.12.6"
 
   required_providers {
-    aws = ">= 2.45, < 4.0"
+    aws = ">= 2.45"
   }
 }

--- a/examples/custom_instance_settings/versions.tf
+++ b/examples/custom_instance_settings/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = ">= 0.12.6, < 0.14"
+  required_version = ">= 0.12.6"
 
   required_providers {
-    aws = ">= 2.45, < 4.0"
+    aws = ">= 2.45"
   }
 }

--- a/examples/mysql/main.tf
+++ b/examples/mysql/main.tf
@@ -87,3 +87,9 @@ resource "aws_iam_policy" "aurora_mysql_policy_iam_auth" {
 }
 POLICY
 }
+
+module "disabled_aurora" {
+  source = "../../"
+
+  create_cluster = false
+}

--- a/examples/mysql/versions.tf
+++ b/examples/mysql/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = ">= 0.12.6, < 0.14"
+  required_version = ">= 0.12.6"
 
   required_providers {
-    aws = ">= 2.45, < 4.0"
+    aws = ">= 2.45"
   }
 }

--- a/examples/postgresql/versions.tf
+++ b/examples/postgresql/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = ">= 0.12.6, < 0.14"
+  required_version = ">= 0.12.6"
 
   required_providers {
-    aws = ">= 2.45, < 4.0"
+    aws = ">= 2.45"
   }
 }

--- a/examples/serverless/versions.tf
+++ b/examples/serverless/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = ">= 0.12.6, < 0.14"
+  required_version = ">= 0.12.6"
 
   required_providers {
-    aws = ">= 2.45, < 4.0"
+    aws = ">= 2.45"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   port                 = var.port == "" ? var.engine == "aurora-postgresql" ? "5432" : "3306" : var.port
-  master_password      = var.password == "" ? element(concat(random_password.master_password.*.result, [""]), 0) : var.password
+  master_password      = var.password == "" && var.is_primary_cluster ? element(concat(random_password.master_password.*.result, [""]) : var.password
   db_subnet_group_name = var.db_subnet_group_name == "" ? join("", aws_db_subnet_group.this.*.name) : var.db_subnet_group_name
   backtrack_window     = (var.engine == "aurora-mysql" || var.engine == "aurora") && var.engine_mode != "serverless" ? var.backtrack_window : 0
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   port                 = var.port == "" ? var.engine == "aurora-postgresql" ? "5432" : "3306" : var.port
-  master_password      = var.password == "" && var.is_primary_cluster ? element(concat(random_password.master_password.*.result, [""]) : var.password
+  master_password      = var.password == "" && var.is_primary_cluster ? element(concat(random_password.master_password.*.result, [""]), 0) : var.password
   db_subnet_group_name = var.db_subnet_group_name == "" ? join("", aws_db_subnet_group.this.*.name) : var.db_subnet_group_name
   backtrack_window     = (var.engine == "aurora-mysql" || var.engine == "aurora") && var.engine_mode != "serverless" ? var.backtrack_window : 0
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,32 +1,32 @@
 # aws_rds_cluster
 output "this_rds_cluster_arn" {
   description = "The ID of the cluster"
-  value       = aws_rds_cluster.this.arn
+  value       = element(concat(aws_rds_cluster.this.*.arn, [""]), 0)
 }
 
 output "this_rds_cluster_id" {
   description = "The ID of the cluster"
-  value       = aws_rds_cluster.this.id
+  value       = element(concat(aws_rds_cluster.this.*.id, [""]), 0)
 }
 
 output "this_rds_cluster_resource_id" {
   description = "The Resource ID of the cluster"
-  value       = aws_rds_cluster.this.cluster_resource_id
+  value       = element(concat(aws_rds_cluster.this.*.cluster_resource_id, [""]), 0)
 }
 
 output "this_rds_cluster_endpoint" {
   description = "The cluster endpoint"
-  value       = aws_rds_cluster.this.endpoint
+  value       = element(concat(aws_rds_cluster.this.*.endpoint, [""]), 0)
 }
 
 output "this_rds_cluster_engine_version" {
   description = "The cluster engine version"
-  value       = aws_rds_cluster.this.engine_version
+  value       = element(concat(aws_rds_cluster.this.*.engine_version, [""]), 0)
 }
 
 output "this_rds_cluster_reader_endpoint" {
   description = "The cluster reader endpoint"
-  value       = aws_rds_cluster.this.reader_endpoint
+  value       = element(concat(aws_rds_cluster.this.*.reader_endpoint, [""]), 0)
 }
 
 # database_name is not set on `aws_rds_cluster` resource if it was not specified, so can't be used in output
@@ -37,23 +37,24 @@ output "this_rds_cluster_database_name" {
 
 output "this_rds_cluster_master_password" {
   description = "The master password"
-  value       = aws_rds_cluster.this.master_password
+  value       = element(concat(aws_rds_cluster.this.*.master_password, [""]), 0)
   sensitive   = true
 }
 
 output "this_rds_cluster_port" {
   description = "The port"
-  value       = aws_rds_cluster.this.port
+  value       = element(concat(aws_rds_cluster.this.*.port, [""]), 0)
 }
 
 output "this_rds_cluster_master_username" {
   description = "The master username"
-  value       = aws_rds_cluster.this.master_username
+  value       = element(concat(aws_rds_cluster.this.*.master_username, [""]), 0)
 }
 
 output "this_rds_cluster_hosted_zone_id" {
   description = "Route53 hosted zone id of the created cluster"
-  value       = aws_rds_cluster.this.hosted_zone_id
+  value       = element(concat(aws_rds_cluster.this.*.hosted_zone_id, [""]), 0)
+
 }
 
 # aws_rds_cluster_instance

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "create_cluster" {
+  description = "Controls if RDS cluster should be created (it affects almost all resources)"
+  type        = bool
+  default     = true
+}
+
 variable "create_security_group" {
   description = "Whether to create security group for RDS cluster"
   type        = bool
@@ -7,6 +13,7 @@ variable "create_security_group" {
 variable "name" {
   description = "Name given resources"
   type        = string
+  default     = ""
 }
 
 variable "subnets" {
@@ -36,6 +43,7 @@ variable "allowed_cidr_blocks" {
 variable "vpc_id" {
   description = "VPC ID"
   type        = string
+  default     = ""
 }
 
 variable "instance_type_replica" {
@@ -47,6 +55,7 @@ variable "instance_type_replica" {
 variable "instance_type" {
   description = "Instance type to use at master instance. If instance_type_replica is not set it will use the same type for replica instances"
   type        = string
+  default     = ""
 }
 
 variable "publicly_accessible" {

--- a/variables.tf
+++ b/variables.tf
@@ -82,6 +82,12 @@ variable "password" {
   default     = ""
 }
 
+variable "is_primary_cluster" {
+  description = "Set this to false if creating a non-primary cluster as part of a Global database"
+  type        = bool
+  default     = true
+}
+
 variable "final_snapshot_identifier_prefix" {
   description = "The prefix name to use when creating a final snapshot on cluster destroy, appends a random 8 digits to name to ensure it's unique too."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -82,6 +82,7 @@ variable "password" {
   default     = ""
 }
 
+# This can be used in addition to username = "" to provide no credentials when creating a non-primary cluster of a Global database
 variable "is_primary_cluster" {
   description = "Set this to false if creating a non-primary cluster as part of a Global database"
   type        = bool

--- a/versions.tf
+++ b/versions.tf
@@ -1,8 +1,8 @@
 terraform {
-  required_version = ">= 0.12.6, < 0.14"
+  required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 2.45, < 4.0"
-    random = "~> 2.2"
+    aws    = ">= 2.45"
+    random = ">= 2.2"
   }
 }


### PR DESCRIPTION
## Description
Add a new variable is_primary_cluster so we can fine-tune the behavior of local.master_password in a special situation that is a valid use-case for the module.

Note that I did not have to modify the code for username in a similar way because we can force it to "" and it will be passed as-is to aws_rds_cluster (leaving the parameter out is not good enough as the default value is "root" and again, we cannot pass a username or a password to aws_rds_cluster when creating a secondary cluster as part of an Aurora Global database.

## Motivation and Context
Without that, there is always a password passed to aws_rds_cluster and this is problematic when adding a secondary cluster to a Global Aurora database.

## Breaking Changes
None as the default value of the new variable makes the change seemless for existing users.

## How Has This Been Tested?
For various reasons (network security issues), I was able to test the same change outside of the repo where I had the module locally (cannot fetch it from the internet with my work setup) and I replicated the lines of code here, but I would not mark it as tested. However, the change is simple and obvious but still.

Fixes #157