### PR TITLE
Don't pass engine_version if engine_mode is serverless

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "aws_rds_cluster" "this" {
   source_region                       = var.source_region
   engine                              = var.engine
   engine_mode                         = var.engine_mode
-  engine_version                      = var.engine_version
+  engine_version                      = var.engine_mode == "serverless" ? null : var.engine_version
   enable_http_endpoint                = var.enable_http_endpoint
   kms_key_id                          = var.kms_key_id
   database_name                       = var.database_name


### PR DESCRIPTION
## Description
Ensures `engine_version` is set to null if `engine_mode` is set to `serverless`

## Motivation and Context
Fixes https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/160

## Breaking Changes
No breaking changes

## How Has This Been Tested?
Tested by passing `engine_version=null` externally via parameter when calling a module.
