### PR TITLE
updating enhanced monitoring arn to use a datasource for partition value

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,5 @@
+data "aws_partition" "current" {}
+
 locals {
   port                 = var.port == "" ? var.engine == "aurora-postgresql" ? "5432" : "3306" : var.port
   master_password      = var.password == "" ? element(concat(random_password.master_password.*.result, [""]), 0) : var.password
@@ -10,6 +12,8 @@ locals {
   rds_security_group_id = join("", aws_security_group.this.*.id)
 
   name = "aurora-${var.name}"
+
+  partition = data.aws_partition.current.partition
 }
 
 # Random string to use as master password unless one is specified
@@ -152,7 +156,7 @@ resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
   count = var.create_cluster && var.create_monitoring_role && var.monitoring_interval > 0 ? 1 : 0
 
   role       = local.rds_enhanced_monitoring_name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+  policy_arn = "arn:${local.partition}:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
 }
 
 resource "aws_appautoscaling_target" "read_replica_count" {

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 data "aws_partition" "current" {}
 
 locals {
+  partition = data.aws_partition.current.partition
   port                 = var.port == "" ? var.engine == "aurora-postgresql" ? "5432" : "3306" : var.port
   master_password      = var.password == "" ? element(concat(random_password.master_password.*.result, [""]), 0) : var.password
   db_subnet_group_name = var.db_subnet_group_name == "" ? join("", aws_db_subnet_group.this.*.name) : var.db_subnet_group_name
@@ -13,7 +14,6 @@ locals {
 
   name = "aurora-${var.name}"
 
-  partition = data.aws_partition.current.partition
 }
 
 # Random string to use as master password unless one is specified


### PR DESCRIPTION
## Description

updating enhanced monitoring arn to using a terraform datasource to lookup the current partition when creating the rds enhanced monitoring role

## Motivation and Context

attempting to attach the AmazonRDSEnhancedMonitoringRole policy to the rds enhanced monitoring role through this module fails in a govcloud account

The policy arn is hardcoded to arn:**aws**:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole with a partition value of **aws**

In an aws us govcloud account, the partition value will be aws-us-gov 

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition
