### PR TITLE
docs: fix supported PostgreSQL log exports to CloudWatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ module "db" {
   db_parameter_group_name         = "default"
   db_cluster_parameter_group_name = "default"
 
-  enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
+  enabled_cloudwatch_logs_exports = ["postgresql"]
 
   tags                            = {
     Environment = "dev"
@@ -120,7 +120,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | db\_subnet\_group\_name | The existing subnet group name to use | `string` | `""` | no |
 | deletion\_protection | If the DB instance should have deletion protection enabled | `bool` | `false` | no |
 | enable\_http\_endpoint | Whether or not to enable the Data API for a serverless Aurora database engine. | `bool` | `false` | no |
-| enabled\_cloudwatch\_logs\_exports | List of log types to export to cloudwatch | `list(string)` | `[]` | no |
+| enabled\_cloudwatch\_logs\_exports | List of log types to export to AWS CloudWatch | `list(string)` | `[]` | no |
 | engine | Aurora database engine type, currently aurora, aurora-mysql or aurora-postgresql | `string` | `"aurora"` | no |
 | engine\_mode | The database engine mode. Valid values: global, parallelquery, provisioned, serverless, multimaster. | `string` | `"provisioned"` | no |
 | engine\_version | Aurora database engine version. | `string` | `"5.6.10a"` | no |

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -34,7 +34,7 @@ module "aurora" {
   skip_final_snapshot             = true
   db_parameter_group_name         = aws_db_parameter_group.aurora_db_postgres96_parameter_group.id
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.aurora_cluster_postgres96_parameter_group.id
-  #  enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
+  #enabled_cloudwatch_logs_exports = ["postgresql"]
 }
 
 resource "aws_db_parameter_group" "aurora_db_postgres96_parameter_group" {

--- a/examples/custom_instance_settings/main.tf
+++ b/examples/custom_instance_settings/main.tf
@@ -29,7 +29,7 @@ module "aurora" {
   skip_final_snapshot             = true
   db_parameter_group_name         = aws_db_parameter_group.aurora_db_postgres11_parameter_group.id
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.aurora_cluster_postgres11_parameter_group.id
-  #  enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
+  #enabled_cloudwatch_logs_exports = ["postgresql"]
   security_group_description = ""
 
   instances_parameters = [

--- a/examples/postgresql/main.tf
+++ b/examples/postgresql/main.tf
@@ -30,7 +30,7 @@ module "aurora" {
   skip_final_snapshot             = true
   db_parameter_group_name         = aws_db_parameter_group.aurora_db_postgres11_parameter_group.id
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.aurora_cluster_postgres11_parameter_group.id
-  #  enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
+  #enabled_cloudwatch_logs_exports = ["postgresql"]
   security_group_description = ""
 }
 


### PR DESCRIPTION
## Description
It seems that Aurora PostgreSQL engine only supports "postgresql" as
valid log to be exported to CloudWatch, any other values not accepted.

## Motivation and Context
The AWS documentation only mentions that value in the examples:
https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.CloudWatch.html
This affects major versions 9.6, 10 and 11 of aurora-postgresql engine.
Related issue: awsdocs/amazon-rds-user-guide#80

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
The examples provided in the repo and the one from README file do not work as is.
After the correction (and uncommenting the line) everything works.