### PR TITLE
feat: Add additional outputs for reader instances and writer instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,9 @@ No modules.
 | <a name="output_rds_cluster_master_username"></a> [rds\_cluster\_master\_username](#output\_rds\_cluster\_master\_username) | The master username |
 | <a name="output_rds_cluster_port"></a> [rds\_cluster\_port](#output\_rds\_cluster\_port) | The port |
 | <a name="output_rds_cluster_reader_endpoint"></a> [rds\_cluster\_reader\_endpoint](#output\_rds\_cluster\_reader\_endpoint) | The cluster reader endpoint |
+| <a name="output_rds_cluster_reader_instance_ids"></a> [rds\_cluster\_reader\_instance\_ids](#output\_rds\_cluster\_reader\_instance\_ids) | A list of all cluster read only instance ids |
 | <a name="output_rds_cluster_resource_id"></a> [rds\_cluster\_resource\_id](#output\_rds\_cluster\_resource\_id) | The Resource ID of the cluster |
+| <a name="output_rds_cluster_writer_instance_ids"></a> [rds\_cluster\_writer\_instance\_ids](#output\_rds\_cluster\_writer\_instance\_ids) | A list of all cluster writer instance ids |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The security group ID of the cluster |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -60,12 +60,12 @@ output "rds_cluster_hosted_zone_id" {
 # aws_rds_cluster_instance
 output "rds_cluster_instance_endpoints" {
   description = "A list of all cluster instance endpoints"
-  value       = aws_rds_cluster_instance.this.*.endpoint
+  value       = [for i in aws_rds_cluster_instance.this : i.endpoint]
 }
 
 output "rds_cluster_instance_ids" {
   description = "A list of all cluster instance ids"
-  value       = aws_rds_cluster_instance.this.*.id
+  value       = [for i in aws_rds_cluster_instance.this : i.id]
 }
 
 output "rds_cluster_instance_dbi_resource_ids" {
@@ -93,4 +93,13 @@ output "enhanced_monitoring_iam_role_arn" {
 output "enhanced_monitoring_iam_role_unique_id" {
   description = "Stable and unique string identifying the enhanced monitoring role"
   value       = element(concat(aws_iam_role.rds_enhanced_monitoring.*.unique_id, [""]), 0)
+}
+output "rds_cluster_reader_instance_ids" {
+  description = "A list of all cluster read only instance ids"
+  value       = [for i in aws_rds_cluster_instance.this : i.id if !i.writer]
+}
+
+output "rds_cluster_writer_instance_ids" {
+  description = "A list of all cluster writer instance ids"
+  value       = [for i in aws_rds_cluster_instance.this : i.id if i.writer]
 }


### PR DESCRIPTION
## Description
Adds two new outputs for accessing the reader instance IDs and writer instance IDs.

## Motivation and Context
Other parts of Terraform build require knowledge of which instances are either readers or writers. With Aurora this is determined on creation, and the current data source for db instances doesn't provide the information.

## Breaking Changes
No breaking changes

## How Has This Been Tested?
It's simply two additional output values, this is tested locally by using the new outputs in other parts of the Terraform codebase.
