### PR TITLE
Update main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -105,9 +105,12 @@ resource "aws_rds_cluster_instance" "this" {
 
   # Updating engine version forces replacement of instances, and they shouldn't be replaced
   # because cluster will update them if engine version is changed
+  # Updating copy tags will be set to false after apply on a cluster, but terraform will store true. 
+  # The instances themselves will have the snapshots as true, but the cluster itself will be set to false. 
   lifecycle {
     ignore_changes = [
-      engine_version
+      engine_version,
+      copy_tags_to_snapshot
     ]
   }
 


### PR DESCRIPTION
We keep getting output to switch the cluster's snapshot to false when we have it set to true in terraform.  The RDS instances themselves have the "copy to snapshots" set to true, but the cluster itself gets reset to false.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
