### PR TITLE
fix: mark "this_rds_cluster_master_username" output as sensitive

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -49,6 +49,7 @@ output "this_rds_cluster_port" {
 output "this_rds_cluster_master_username" {
   description = "The master username"
   value       = element(concat(aws_rds_cluster.this.*.master_username, [""]), 0)
+  sensitive = true
 }
 
 output "this_rds_cluster_hosted_zone_id" {


### PR DESCRIPTION
## Description
Marking the `username` output field as sensitive, as this now seems to be required by the AWS provider

## Motivation and Context
Our terraform cloud workspaces now, either with an upgrade to terraform >=0.14.3 or an upgrade of the aws provider version, now result in a plan error stating that the username field should be marked as sensitive:
```
Error: Output refers to sensitive values

  on .terraform/modules/XXX/outputs.tf line 49:
  49: output "this_rds_cluster_master_username" {

Expressions used in outputs can only refer to sensitive values if the
sensitive attribute is true.
```
after applying this change on our fork to mark the username output as sensitive and using our forked repo as the provider (with no other diff to this main repo), the error no longer occurred and our plan + apply went through OK

## Breaking Changes
None that we can see or determine. There is an update change in the plan output now that is just informing you of the newly marked sensitivity of the field.

## How Has This Been Tested?
We have run our terraform plans + applies against our fork with the field marked as sensitive. We have not seen any planned changes to the resources (other than the info about the new field status mentioned above), no modifications to our aurora instances, no newly pending maintenance as a result of applying this change.