### PR TITLE
feat: Support major version engine upgrades

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.43.0
+    rev: v1.45.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
@@ -20,6 +20,6 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.4.0
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -89,20 +89,21 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6 |
-| aws | >= 2.45 |
+| aws | >= 3.8 |
 | random | >= 2.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.45 |
+| aws | >= 3.8 |
 | random | >= 2.2 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| allow\_major\_version\_upgrade | Determines whether major engine upgrades are allowed when changing engine version | `bool` | `false` | no |
 | allowed\_cidr\_blocks | A list of CIDR blocks which are allowed to access the database | `list(string)` | `[]` | no |
 | allowed\_security\_groups | A list of Security Group ID's to allow access to. | `list(string)` | `[]` | no |
 | apply\_immediately | Determines whether or not any DB modifications are applied immediately, or during the maintenance window | `bool` | `false` | no |

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws = ">= 2.45"
+    aws = ">= 3.8"
   }
 }

--- a/examples/custom_instance_settings/versions.tf
+++ b/examples/custom_instance_settings/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws = ">= 2.45"
+    aws = ">= 3.8"
   }
 }

--- a/examples/mysql/versions.tf
+++ b/examples/mysql/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 2.45"
+    aws    = ">= 3.8"
     random = ">= 2.2"
   }
 }

--- a/examples/postgresql/versions.tf
+++ b/examples/postgresql/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws = ">= 2.45"
+    aws = ">= 3.8"
   }
 }

--- a/examples/serverless/versions.tf
+++ b/examples/serverless/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws = ">= 2.45"
+    aws = ">= 3.8"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,7 @@ resource "aws_rds_cluster" "this" {
   engine                              = var.engine
   engine_mode                         = var.engine_mode
   engine_version                      = var.engine_version
+  allow_major_version_upgrade         = var.allow_major_version_upgrade
   enable_http_endpoint                = var.enable_http_endpoint
   kms_key_id                          = var.kms_key_id
   database_name                       = var.database_name

--- a/variables.tf
+++ b/variables.tf
@@ -166,6 +166,12 @@ variable "monitoring_interval" {
   default     = 0
 }
 
+variable "allow_major_version_upgrade" {
+  description = "Determines whether major engine upgrades are allowed when changing engine version"
+  type        = bool
+  default     = false
+}
+
 variable "auto_minor_version_upgrade" {
   description = "Determines whether minor engine upgrades will be performed automatically in the maintenance window"
   type        = bool

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 2.45"
+    aws    = ">= 3.8"
     random = ">= 2.2"
   }
 }


### PR DESCRIPTION
Exposes the same aws_rds_cluster resource variable as a module variable. Defaults to the same value to preserve backwards compatibility.

see:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#allow_major_version_upgrade