### PR TITLE
chore: update documentation based on latest `terraform-docs` which includes module and resource sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,29 @@
-.terraform
-terraform.tfstate
-*.tfstate*
-terraform.tfvars
+# Local .terraform directories
+**/.terraform/*
+
+# Terraform lockfile
 .terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.46.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -99,6 +99,27 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | aws | >= 3.8 |
 | random | >= 2.2 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_appautoscaling_policy](https://registry.terraform.io/providers/hashicorp/aws/3.8/docs/resources/appautoscaling_policy) |
+| [aws_appautoscaling_target](https://registry.terraform.io/providers/hashicorp/aws/3.8/docs/resources/appautoscaling_target) |
+| [aws_db_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/3.8/docs/resources/db_subnet_group) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/3.8/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/3.8/docs/resources/iam_role) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.8/docs/resources/iam_role_policy_attachment) |
+| [aws_rds_cluster](https://registry.terraform.io/providers/hashicorp/aws/3.8/docs/resources/rds_cluster) |
+| [aws_rds_cluster_instance](https://registry.terraform.io/providers/hashicorp/aws/3.8/docs/resources/rds_cluster_instance) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.8/docs/resources/security_group) |
+| [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/3.8/docs/resources/security_group_rule) |
+| [random_id](https://registry.terraform.io/providers/hashicorp/random/2.2/docs/resources/id) |
+| [random_password](https://registry.terraform.io/providers/hashicorp/random/2.2/docs/resources/password) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -187,7 +208,6 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | this\_rds\_cluster\_reader\_endpoint | The cluster reader endpoint |
 | this\_rds\_cluster\_resource\_id | The Resource ID of the cluster |
 | this\_security\_group\_id | The security group ID of the cluster |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -111,12 +111,12 @@ No Modules.
 | [aws_appautoscaling_target](https://registry.terraform.io/providers/hashicorp/aws/3.8/docs/resources/appautoscaling_target) |
 | [aws_db_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/3.8/docs/resources/db_subnet_group) |
 | [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/3.8/docs/data-sources/iam_policy_document) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/3.8/docs/resources/iam_role) |
 | [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.8/docs/resources/iam_role_policy_attachment) |
-| [aws_rds_cluster](https://registry.terraform.io/providers/hashicorp/aws/3.8/docs/resources/rds_cluster) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/3.8/docs/resources/iam_role) |
 | [aws_rds_cluster_instance](https://registry.terraform.io/providers/hashicorp/aws/3.8/docs/resources/rds_cluster_instance) |
-| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.8/docs/resources/security_group) |
+| [aws_rds_cluster](https://registry.terraform.io/providers/hashicorp/aws/3.8/docs/resources/rds_cluster) |
 | [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/3.8/docs/resources/security_group_rule) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.8/docs/resources/security_group) |
 | [random_id](https://registry.terraform.io/providers/hashicorp/random/2.2/docs/resources/id) |
 | [random_password](https://registry.terraform.io/providers/hashicorp/random/2.2/docs/resources/password) |
 


### PR DESCRIPTION
## Description
- update documentation based on latest `terraform-docs` which includes module and resource sections
- `.gitignore` updated using GitHub provided default standard + 0.14 lockfile ignore

## Motivation and Context
- these are two new sections provided by [`terraform-docs` now](https://github.com/terraform-docs/terraform-docs/releases/tag/v0.11.0)

## Breaking Changes
No

## How Has This Been Tested?
N/A
