### PR TITLE
fix: Specify the number of read replicas as one less that total (#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
+- fix: Specify the number of read replicas as one less that total instances ([#190](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/190))
 
 
 <a name="v3.5.0"></a>

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | replica\_scale\_cpu | CPU usage to trigger autoscaling at | `number` | `70` | no |
 | replica\_scale\_enabled | Whether to enable autoscaling for RDS Aurora (MySQL) read replicas | `bool` | `false` | no |
 | replica\_scale\_in\_cooldown | Cooldown in seconds before allowing further scaling operations after a scale in | `number` | `300` | no |
-| replica\_scale\_max | Maximum number of replicas to allow scaling for | `number` | `0` | no |
-| replica\_scale\_min | Minimum number of replicas to allow scaling for | `number` | `2` | no |
+| replica\_scale\_max | Maximum number of read replicas to allow scaling for | `number` | `0` | no |
+| replica\_scale\_min | Minimum number of read replicas to allow scaling for | `number` | `2` | no |
 | replica\_scale\_out\_cooldown | Cooldown in seconds before allowing further scaling operations after a scale out | `number` | `300` | no |
 | replication\_source\_identifier | ARN of a source DB cluster or DB instance if this DB cluster is to be created as a Read Replica. | `string` | `""` | no |
 | scaling\_configuration | Map of nested attributes with scaling properties. Only valid when engine\_mode is set to `serverless` | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -84,7 +84,7 @@ resource "aws_rds_cluster" "this" {
 }
 
 resource "aws_rds_cluster_instance" "this" {
-  count = var.create_cluster ? (var.replica_scale_enabled ? var.replica_scale_min : var.replica_count) : 0
+  count = var.create_cluster ? (var.replica_scale_enabled ? var.replica_scale_min + 1: var.replica_count + 1) : 0
 
   identifier                      = length(var.instances_parameters) > count.index ? lookup(var.instances_parameters[count.index], "instance_name", "${var.name}-${count.index + 1}") : "${var.name}-${count.index + 1}"
   cluster_identifier              = element(concat(aws_rds_cluster.this.*.id, [""]), 0)

--- a/variables.tf
+++ b/variables.tf
@@ -239,13 +239,13 @@ variable "replica_scale_enabled" {
 }
 
 variable "replica_scale_max" {
-  description = "Maximum number of replicas to allow scaling for"
+  description = "Maximum number of read replicas to allow scaling for"
   type        = number
   default     = 0
 }
 
 variable "replica_scale_min" {
-  description = "Minimum number of replicas to allow scaling for"
+  description = "Minimum number of read replicas to allow scaling for"
   type        = number
   default     = 2
 }


### PR DESCRIPTION
## Description
`replica_scale_min` and `replica_count` are used incorrectly as the total cluster node count.

## Motivation and Context
Currently setting read replicas to 0 deletes the writer instance.
Once extra auto scaling read replicas gets created with the auto-scaling policy, wasting money.

## Breaking Changes
None.

## How Has This Been Tested?
Created a cluster with zero read replicas, one writer and zero read replicas were created
Created a cluster with one read replicas, one writer and one read replicas were created
Created a cluster with two read replicas, one writer and two read replicas were created

