### PR TITLE
feat: AWS Instance Scheduler Tagging Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ No Modules.
 | backtrack\_window | The target backtrack window, in seconds. Only available for aurora engine currently. To disable backtracking, set this value to 0. Defaults to 0. Must be between 0 and 259200 (72 hours) | `number` | `0` | no |
 | backup\_retention\_period | How long to keep backups for (in days) | `number` | `7` | no |
 | ca\_cert\_identifier | The identifier of the CA certificate for the DB instance | `string` | `"rds-ca-2019"` | no |
+| cluster\_specific\_tags | A map of tags to add to only the RDS cluster. Used for AWS Instance Scheduler tagging. | `map(string)` | `{}` | no |
 | copy\_tags\_to\_snapshot | Copy all Cluster tags to snapshots. | `bool` | `false` | no |
 | create\_cluster | Controls if RDS cluster should be created (it affects almost all resources) | `bool` | `true` | no |
 | create\_monitoring\_role | Whether to create the IAM role for RDS enhanced monitoring | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ No Modules.
 | backtrack\_window | The target backtrack window, in seconds. Only available for aurora engine currently. To disable backtracking, set this value to 0. Defaults to 0. Must be between 0 and 259200 (72 hours) | `number` | `0` | no |
 | backup\_retention\_period | How long to keep backups for (in days) | `number` | `7` | no |
 | ca\_cert\_identifier | The identifier of the CA certificate for the DB instance | `string` | `"rds-ca-2019"` | no |
-| cluster\_specific\_tags | A map of tags to add to only the RDS cluster. Used for AWS Instance Scheduler tagging. | `map(string)` | `{}` | no |
+| cluster\_tags | A map of tags to add to only the RDS cluster. Used for AWS Instance Scheduler tagging. | `map(string)` | `{}` | no |
 | copy\_tags\_to\_snapshot | Copy all Cluster tags to snapshots. | `bool` | `false` | no |
 | create\_cluster | Controls if RDS cluster should be created (it affects almost all resources) | `bool` | `true` | no |
 | create\_monitoring\_role | Whether to create the IAM role for RDS enhanced monitoring | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ resource "aws_rds_cluster" "this" {
     }
   }
 
-  tags = var.tags
+  tags = merge(var.tags, var.cluster_specific_tags)
 }
 
 resource "aws_rds_cluster_instance" "this" {

--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ resource "aws_rds_cluster" "this" {
     }
   }
 
-  tags = merge(var.tags, var.cluster_specific_tags)
+  tags = merge(var.tags, var.cluster_tags)
 }
 
 resource "aws_rds_cluster_instance" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -280,6 +280,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "cluster_specific_tags" {
+  description = "A map of tags to add to only the RDS cluster. Used for AWS Instance Scheduler tagging."
+  type        = map(string)
+  default     = {}
+}
+
 variable "performance_insights_enabled" {
   description = "Specifies whether Performance Insights is enabled or not."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -280,7 +280,7 @@ variable "tags" {
   default     = {}
 }
 
-variable "cluster_specific_tags" {
+variable "cluster_tags" {
   description = "A map of tags to add to only the RDS cluster. Used for AWS Instance Scheduler tagging."
   type        = map(string)
   default     = {}


### PR DESCRIPTION
## Description
This change adds a new input variable for the module that allows tags to be applied to the RDS cluster only. Existing functionality with the current tags variable is preserved by using a merge of the two maps.

## Motivation and Context
Motivation for adding this new input is that the [AWS Instance Scheduler](https://docs.aws.amazon.com/solutions/latest/instance-scheduler/welcome.html) requires tags be added to the RDS cluster **only** for it to work (i.e. there cannot be a schedule tag added to the RDS instance). Therefore this change is being introduced to allow some tags to specifically be added to the cluster.

## Breaking Changes
No breaking changes. This only introduces one new input variable and merges it into the existing tags on the RDS cluster.

## How Has This Been Tested?
This change has been tested in development and staging environments and works as expected. AWS Instance Scheduler picks up these tagged clusters and starts/stops them as needed.
