### PR TITLE
chore: add all attributes and some outputs for enhanced monitoring IAM role

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,15 +122,15 @@ No Modules.
 |------|-------------|------|---------|:--------:|
 | allow\_major\_version\_upgrade | Determines whether major engine upgrades are allowed when changing engine version | `bool` | `false` | no |
 | allowed\_cidr\_blocks | A list of CIDR blocks which are allowed to access the database | `list(string)` | `[]` | no |
-| allowed\_security\_groups | A list of Security Group ID's to allow access to. | `list(string)` | `[]` | no |
+| allowed\_security\_groups | A list of Security Group ID's to allow access to | `list(string)` | `[]` | no |
 | apply\_immediately | Determines whether or not any DB modifications are applied immediately, or during the maintenance window | `bool` | `false` | no |
 | auto\_minor\_version\_upgrade | Determines whether minor engine upgrades will be performed automatically in the maintenance window | `bool` | `true` | no |
-| backtrack\_window | The target backtrack window, in seconds. Only available for aurora engine currently. To disable backtracking, set this value to 0. Defaults to 0. Must be between 0 and 259200 (72 hours) | `number` | `0` | no |
+| backtrack\_window | The target backtrack window, in seconds. Only available for aurora engine currently. To disable backtracking, set this value to 0. Must be between 0 and 259200 (72 hours) | `number` | `0` | no |
 | backup\_retention\_period | How long to keep backups for (in days) | `number` | `7` | no |
 | ca\_cert\_identifier | The identifier of the CA certificate for the DB instance | `string` | `"rds-ca-2019"` | no |
-| cluster\_tags | A map of tags to add to only the RDS cluster. Used for AWS Instance Scheduler tagging. | `map(string)` | `{}` | no |
-| copy\_tags\_to\_snapshot | Copy all Cluster tags to snapshots. | `bool` | `false` | no |
-| create\_cluster | Controls if RDS cluster should be created (it affects almost all resources) | `bool` | `true` | no |
+| cluster\_tags | A map of tags to add to only the RDS cluster. Used for AWS Instance Scheduler tagging | `map(string)` | `{}` | no |
+| copy\_tags\_to\_snapshot | Copy all Cluster tags to snapshots | `bool` | `false` | no |
+| create\_cluster | Whether cluster should be created (it affects almost all resources) | `bool` | `true` | no |
 | create\_monitoring\_role | Whether to create the IAM role for RDS enhanced monitoring | `bool` | `true` | no |
 | create\_random\_password | Whether to create random password for RDS primary cluster | `bool` | `true` | no |
 | create\_security\_group | Whether to create security group for RDS cluster | `bool` | `true` | no |
@@ -139,14 +139,14 @@ No Modules.
 | db\_parameter\_group\_name | The name of a DB parameter group to use | `string` | `null` | no |
 | db\_subnet\_group\_name | The existing subnet group name to use | `string` | `""` | no |
 | deletion\_protection | If the DB instance should have deletion protection enabled | `bool` | `false` | no |
-| enable\_http\_endpoint | Whether or not to enable the Data API for a serverless Aurora database engine. | `bool` | `false` | no |
-| enabled\_cloudwatch\_logs\_exports | List of log types to export to cloudwatch | `list(string)` | `[]` | no |
+| enable\_http\_endpoint | Whether or not to enable the Data API for a serverless Aurora database engine | `bool` | `false` | no |
+| enabled\_cloudwatch\_logs\_exports | List of log types to export to cloudwatch - `audit`, `error`, `general`, `slowquery`, `postgresql` | `list(string)` | `[]` | no |
 | engine | Aurora database engine type, currently aurora, aurora-mysql or aurora-postgresql | `string` | `"aurora"` | no |
-| engine\_mode | The database engine mode. Valid values: global, parallelquery, provisioned, serverless, multimaster. | `string` | `"provisioned"` | no |
-| engine\_version | Aurora database engine version. | `string` | `"5.6.10a"` | no |
+| engine\_mode | The database engine mode. Valid values: global, parallelquery, provisioned, serverless, multimaster | `string` | `"provisioned"` | no |
+| engine\_version | Aurora database engine version | `string` | `"5.6.10a"` | no |
 | final\_snapshot\_identifier\_prefix | The prefix name to use when creating a final snapshot on cluster destroy, appends a random 8 digits to name to ensure it's unique too. | `string` | `"final"` | no |
 | global\_cluster\_identifier | The global cluster identifier specified on aws\_rds\_global\_cluster | `string` | `""` | no |
-| iam\_database\_authentication\_enabled | Specifies whether IAM Database authentication should be enabled or not. Not all versions and instances are supported. Refer to the AWS documentation to see which versions are supported. | `bool` | `false` | no |
+| iam\_database\_authentication\_enabled | Specifies whether IAM Database authentication should be enabled or not. Not all versions and instances are supported. Refer to the AWS documentation to see which versions are supported | `bool` | `false` | no |
 | iam\_role\_description | Description of the role | `string` | `null` | no |
 | iam\_role\_force\_detach\_policies | Whether to force detaching any policies the role has before destroying it | `bool` | `null` | no |
 | iam\_role\_managed\_policy\_arns | Set of exclusive IAM managed policy ARNs to attach to the IAM role | `list(string)` | `null` | no |
@@ -155,40 +155,40 @@ No Modules.
 | iam\_role\_path | Path to the role | `string` | `null` | no |
 | iam\_role\_permissions\_boundary | The ARN of the policy that is used to set the permissions boundary for the role | `string` | `null` | no |
 | iam\_role\_use\_name\_prefix | Whether to use `iam_role_name` as is or create a unique name beginning with the `iam_role_name` as the prefix | `bool` | `false` | no |
-| iam\_roles | A List of ARNs for the IAM roles to associate to the RDS Cluster. | `list(string)` | `[]` | no |
+| iam\_roles | A List of ARNs for the IAM roles to associate to the RDS Cluster | `list(string)` | `[]` | no |
 | instance\_type | Instance type to use at master instance. If instance\_type\_replica is not set it will use the same type for replica instances | `string` | `""` | no |
 | instance\_type\_replica | Instance type to use at replica instance | `string` | `null` | no |
-| instances\_parameters | Customized instance settings. Supported keys: instance\_name, instance\_type, instance\_promotion\_tier, publicly\_accessible | `list(map(string))` | `[]` | no |
+| instances\_parameters | Customized instance settings. Supported keys: `instance_name`, `instance_type`, `instance_promotion_tier`, `publicly_accessible` | `list(map(string))` | `[]` | no |
 | is\_primary\_cluster | Whether to create a primary cluster (set to false to be a part of a Global database) | `bool` | `true` | no |
-| kms\_key\_id | The ARN for the KMS encryption key if one is set to the cluster. | `string` | `""` | no |
+| kms\_key\_id | The ARN for the KMS encryption key if one is set to the cluster | `string` | `""` | no |
 | monitoring\_interval | The interval (seconds) between points when Enhanced Monitoring metrics are collected | `number` | `0` | no |
 | monitoring\_role\_arn | IAM role used by RDS to send enhanced monitoring metrics to CloudWatch | `string` | `""` | no |
 | name | Name used across resources created | `string` | `""` | no |
 | password | Master DB password | `string` | `""` | no |
-| performance\_insights\_enabled | Specifies whether Performance Insights is enabled or not. | `bool` | `false` | no |
-| performance\_insights\_kms\_key\_id | The ARN for the KMS key to encrypt Performance Insights data. | `string` | `""` | no |
+| performance\_insights\_enabled | Specifies whether Performance Insights is enabled or not | `bool` | `false` | no |
+| performance\_insights\_kms\_key\_id | The ARN for the KMS key to encrypt Performance Insights data | `string` | `""` | no |
 | port | The port on which to accept connections | `string` | `""` | no |
-| predefined\_metric\_type | The metric type to scale on. Valid values are RDSReaderAverageCPUUtilization and RDSReaderAverageDatabaseConnections. | `string` | `"RDSReaderAverageCPUUtilization"` | no |
+| predefined\_metric\_type | The metric type to scale on. Valid values are RDSReaderAverageCPUUtilization and RDSReaderAverageDatabaseConnections | `string` | `"RDSReaderAverageCPUUtilization"` | no |
 | preferred\_backup\_window | When to perform DB backups | `string` | `"02:00-03:00"` | no |
 | preferred\_maintenance\_window | When to perform DB maintenance | `string` | `"sun:05:00-sun:06:00"` | no |
 | publicly\_accessible | Whether the DB should have a public IP address | `bool` | `false` | no |
 | replica\_count | Number of reader nodes to create.  If `replica_scale_enable` is `true`, the value of `replica_scale_min` is used instead. | `number` | `1` | no |
-| replica\_scale\_connections | Average number of connections to trigger autoscaling at. Default value is 70% of db.r4.large's default max\_connections | `number` | `700` | no |
-| replica\_scale\_cpu | CPU usage to trigger autoscaling at | `number` | `70` | no |
+| replica\_scale\_connections | Average number of connections threshold which will initiate autoscaling. Default value is 70% of db.r4.large's default max\_connections | `number` | `700` | no |
+| replica\_scale\_cpu | CPU threshold which will initiate autoscaling | `number` | `70` | no |
 | replica\_scale\_enabled | Whether to enable autoscaling for RDS Aurora (MySQL) read replicas | `bool` | `false` | no |
 | replica\_scale\_in\_cooldown | Cooldown in seconds before allowing further scaling operations after a scale in | `number` | `300` | no |
-| replica\_scale\_max | Maximum number of replicas to allow scaling for | `number` | `0` | no |
-| replica\_scale\_min | Minimum number of replicas to allow scaling for | `number` | `2` | no |
+| replica\_scale\_max | Maximum number of read replicas permitted when autoscaling is enabled | `number` | `0` | no |
+| replica\_scale\_min | Minimum number of read replicas permitted when autoscaling is enabled | `number` | `2` | no |
 | replica\_scale\_out\_cooldown | Cooldown in seconds before allowing further scaling operations after a scale out | `number` | `300` | no |
-| replication\_source\_identifier | ARN of a source DB cluster or DB instance if this DB cluster is to be created as a Read Replica. | `string` | `""` | no |
-| s3\_import | Restore from a Percona Xtrabackup in S3 (only MySQL is supported) | `map(string)` | `null` | no |
+| replication\_source\_identifier | ARN of a source DB cluster or DB instance if this DB cluster is to be created as a Read Replica | `string` | `""` | no |
+| s3\_import | Configuration map used to restore from a Percona Xtrabackup in S3 (only MySQL is supported) | `map(string)` | `null` | no |
 | scaling\_configuration | Map of nested attributes with scaling properties. Only valid when engine\_mode is set to `serverless` | `map(string)` | `{}` | no |
-| security\_group\_description | The description of the security group. If value is set to empty string it will contain cluster name in the description. | `string` | `"Managed by Terraform"` | no |
+| security\_group\_description | The description of the security group. If value is set to empty string it will contain cluster name in the description | `string` | `"Managed by Terraform"` | no |
 | skip\_final\_snapshot | Should a final snapshot be created on cluster destroy | `bool` | `false` | no |
 | snapshot\_identifier | DB snapshot to create this database from | `string` | `null` | no |
-| source\_region | The source region for an encrypted replica DB cluster. | `string` | `""` | no |
+| source\_region | The source region for an encrypted replica DB cluster | `string` | `""` | no |
 | storage\_encrypted | Specifies whether the underlying storage layer should be encrypted | `bool` | `true` | no |
-| subnets | List of subnet IDs to use | `list(string)` | `[]` | no |
+| subnets | List of subnet IDs used by database subnet group created | `list(string)` | `[]` | no |
 | tags | A map of tags to add to all resources. | `map(string)` | `{}` | no |
 | username | Master DB username | `string` | `"root"` | no |
 | vpc\_id | VPC ID | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ No Modules.
 | monitoring\_interval | The interval (seconds) between points when Enhanced Monitoring metrics are collected | `number` | `0` | no |
 | monitoring\_role\_arn | IAM role used by RDS to send enhanced monitoring metrics to CloudWatch | `string` | `""` | no |
 | name | Name used across resources created | `string` | `""` | no |
-| password | Master DB password | `string` | `""` | no |
+| password | Master DB password. Note - when specifying a value here, 'create\_random\_password' should be set to `false` | `string` | `""` | no |
 | performance\_insights\_enabled | Specifies whether Performance Insights is enabled or not | `bool` | `false` | no |
 | performance\_insights\_kms\_key\_id | The ARN for the KMS key to encrypt Performance Insights data | `string` | `""` | no |
 | port | The port on which to accept connections | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ No Modules.
 | [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
 | [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
 | [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
+| [aws_partition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) |
 | [aws_rds_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) |
 | [aws_rds_cluster_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance) |
 | [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) |
@@ -146,7 +147,14 @@ No Modules.
 | final\_snapshot\_identifier\_prefix | The prefix name to use when creating a final snapshot on cluster destroy, appends a random 8 digits to name to ensure it's unique too. | `string` | `"final"` | no |
 | global\_cluster\_identifier | The global cluster identifier specified on aws\_rds\_global\_cluster | `string` | `""` | no |
 | iam\_database\_authentication\_enabled | Specifies whether IAM Database authentication should be enabled or not. Not all versions and instances are supported. Refer to the AWS documentation to see which versions are supported. | `bool` | `false` | no |
-| iam\_partition | IAM Partition to use when generating ARN's. For most regions this can be left at default. China/Govcloud use different partitions | `string` | `"aws"` | no |
+| iam\_role\_description | Description of the role | `string` | `null` | no |
+| iam\_role\_force\_detach\_policies | Whether to force detaching any policies the role has before destroying it | `bool` | `null` | no |
+| iam\_role\_managed\_policy\_arns | Set of exclusive IAM managed policy ARNs to attach to the IAM role | `list(string)` | `null` | no |
+| iam\_role\_max\_session\_duration | Maximum session duration (in seconds) that you want to set for the role | `number` | `null` | no |
+| iam\_role\_name | Friendly name of the role | `string` | `null` | no |
+| iam\_role\_path | Path to the role | `string` | `null` | no |
+| iam\_role\_permissions\_boundary | The ARN of the policy that is used to set the permissions boundary for the role | `string` | `null` | no |
+| iam\_role\_use\_name\_prefix | Whether to use `iam_role_name` as is or create a unique name beginning with the `iam_role_name` as the prefix | `bool` | `false` | no |
 | iam\_roles | A List of ARNs for the IAM roles to associate to the RDS Cluster. | `list(string)` | `[]` | no |
 | instance\_type | Instance type to use at master instance. If instance\_type\_replica is not set it will use the same type for replica instances | `string` | `""` | no |
 | instance\_type\_replica | Instance type to use at replica instance | `string` | `null` | no |
@@ -154,12 +162,11 @@ No Modules.
 | is\_primary\_cluster | Whether to create a primary cluster (set to false to be a part of a Global database) | `bool` | `true` | no |
 | kms\_key\_id | The ARN for the KMS encryption key if one is set to the cluster. | `string` | `""` | no |
 | monitoring\_interval | The interval (seconds) between points when Enhanced Monitoring metrics are collected | `number` | `0` | no |
-| monitoring\_role\_arn | IAM role for RDS to send enhanced monitoring metrics to CloudWatch | `string` | `""` | no |
-| name | Name given resources | `string` | `""` | no |
+| monitoring\_role\_arn | IAM role used by RDS to send enhanced monitoring metrics to CloudWatch | `string` | `""` | no |
+| name | Name used across resources created | `string` | `""` | no |
 | password | Master DB password | `string` | `""` | no |
 | performance\_insights\_enabled | Specifies whether Performance Insights is enabled or not. | `bool` | `false` | no |
 | performance\_insights\_kms\_key\_id | The ARN for the KMS key to encrypt Performance Insights data. | `string` | `""` | no |
-| permissions\_boundary | The ARN of the policy that is used to set the permissions boundary for the role. | `string` | `null` | no |
 | port | The port on which to accept connections | `string` | `""` | no |
 | predefined\_metric\_type | The metric type to scale on. Valid values are RDSReaderAverageCPUUtilization and RDSReaderAverageDatabaseConnections. | `string` | `"RDSReaderAverageCPUUtilization"` | no |
 | preferred\_backup\_window | When to perform DB backups | `string` | `"02:00-03:00"` | no |
@@ -191,6 +198,9 @@ No Modules.
 
 | Name | Description |
 |------|-------------|
+| this\_enhanced\_monitoring\_iam\_role\_arn | The Amazon Resource Name (ARN) specifying the enhanced monitoring role |
+| this\_enhanced\_monitoring\_iam\_role\_name | The name of the enhanced monitoring role |
+| this\_enhanced\_monitoring\_iam\_role\_unique\_id | Stable and unique string identifying the enhanced monitoring role |
 | this\_rds\_cluster\_arn | The ID of the cluster |
 | this\_rds\_cluster\_database\_name | Name for an automatically created database on cluster creation |
 | this\_rds\_cluster\_endpoint | The cluster endpoint |

--- a/examples/autoscaling/README.md
+++ b/examples/autoscaling/README.md
@@ -51,6 +51,9 @@ No input.
 
 | Name | Description |
 |------|-------------|
+| this\_enhanced\_monitoring\_iam\_role\_arn | The Amazon Resource Name (ARN) specifying the enhanced monitoring role |
+| this\_enhanced\_monitoring\_iam\_role\_name | The name of the enhanced monitoring role |
+| this\_enhanced\_monitoring\_iam\_role\_unique\_id | Stable and unique string identifying the enhanced monitoring role |
 | this\_rds\_cluster\_database\_name | Name for an automatically created database on cluster creation |
 | this\_rds\_cluster\_endpoint | The cluster endpoint |
 | this\_rds\_cluster\_id | The ID of the cluster |

--- a/examples/autoscaling/main.tf
+++ b/examples/autoscaling/main.tf
@@ -53,7 +53,12 @@ module "aurora" {
   replica_scale_min     = 1
   replica_scale_max     = 5
 
-  monitoring_interval = 60
+  monitoring_interval           = 60
+  iam_role_name                 = "${local.name}-enhanced-monitoring"
+  iam_role_use_name_prefix      = true
+  iam_role_description          = "${local.name} RDS enhanced monitoring IAM role"
+  iam_role_path                 = "/autoscaling/"
+  iam_role_max_session_duration = 7200
 
   apply_immediately   = true
   skip_final_snapshot = true

--- a/examples/autoscaling/outputs.tf
+++ b/examples/autoscaling/outputs.tf
@@ -56,3 +56,19 @@ output "this_security_group_id" {
   description = "The security group ID of the cluster"
   value       = module.aurora.this_security_group_id
 }
+
+# Enhanced monitoring role
+output "this_enhanced_monitoring_iam_role_name" {
+  description = "The name of the enhanced monitoring role"
+  value       = module.aurora.this_enhanced_monitoring_iam_role_name
+}
+
+output "this_enhanced_monitoring_iam_role_arn" {
+  description = "The Amazon Resource Name (ARN) specifying the enhanced monitoring role"
+  value       = module.aurora.this_enhanced_monitoring_iam_role_arn
+}
+
+output "this_enhanced_monitoring_iam_role_unique_id" {
+  description = "Stable and unique string identifying the enhanced monitoring role"
+  value       = module.aurora.this_enhanced_monitoring_iam_role_unique_id
+}

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  port                 = var.port == "" ? var.engine == "aurora-postgresql" ? 5432 : 3306 : var.port
+  port                 = var.port == "" ? (var.engine == "aurora-postgresql" ? 5432 : 3306) : var.port
   db_subnet_group_name = var.db_subnet_group_name == "" ? join("", aws_db_subnet_group.this.*.name) : var.db_subnet_group_name
   master_password      = var.create_cluster && var.create_random_password && var.is_primary_cluster ? random_password.master_password[0].result : var.password
   backtrack_window     = (var.engine == "aurora-mysql" || var.engine == "aurora") && var.engine_mode != "serverless" ? var.backtrack_window : 0

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ locals {
   rds_enhanced_monitoring_arn = var.create_monitoring_role ? join("", aws_iam_role.rds_enhanced_monitoring.*.arn) : var.monitoring_role_arn
   rds_security_group_id       = join("", aws_security_group.this.*.id)
 
-  #                                                            # Required for backwards compatibility
+  # TODO - remove coalesce() at next breaking change - adding existing name as fallback to maintain backwards compatibility
   iam_role_name        = var.iam_role_use_name_prefix ? null : coalesce(var.iam_role_name, "rds-enhanced-monitoring-${var.name}")
   iam_role_name_prefix = var.iam_role_use_name_prefix ? "${var.iam_role_name}-" : null
 

--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,21 @@
 locals {
-  port                 = var.port == "" ? var.engine == "aurora-postgresql" ? "5432" : "3306" : var.port
+  port                 = var.port == "" ? var.engine == "aurora-postgresql" ? 5432 : 3306 : var.port
   db_subnet_group_name = var.db_subnet_group_name == "" ? join("", aws_db_subnet_group.this.*.name) : var.db_subnet_group_name
   master_password      = var.create_cluster && var.create_random_password && var.is_primary_cluster ? random_password.master_password[0].result : var.password
   backtrack_window     = (var.engine == "aurora-mysql" || var.engine == "aurora") && var.engine_mode != "serverless" ? var.backtrack_window : 0
 
-  rds_enhanced_monitoring_arn  = var.create_monitoring_role ? join("", aws_iam_role.rds_enhanced_monitoring.*.arn) : var.monitoring_role_arn
-  rds_enhanced_monitoring_name = join("", aws_iam_role.rds_enhanced_monitoring.*.name)
+  rds_enhanced_monitoring_arn = var.create_monitoring_role ? join("", aws_iam_role.rds_enhanced_monitoring.*.arn) : var.monitoring_role_arn
+  rds_security_group_id       = join("", aws_security_group.this.*.id)
 
-  rds_security_group_id = join("", aws_security_group.this.*.id)
+  #                                                            # Required for backwards compatibility
+  iam_role_name        = var.iam_role_use_name_prefix ? null : coalesce(var.iam_role_name, "rds-enhanced-monitoring-${var.name}")
+  iam_role_name_prefix = var.iam_role_use_name_prefix ? "${var.iam_role_name}-" : null
 
   name = "aurora-${var.name}"
 }
+
+# Ref. https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces
+data "aws_partition" "current" {}
 
 # Random string to use as master password
 resource "random_password" "master_password" {
@@ -18,6 +23,16 @@ resource "random_password" "master_password" {
 
   length  = 10
   special = false
+}
+
+resource "random_id" "snapshot_identifier" {
+  count = var.create_cluster ? 1 : 0
+
+  keepers = {
+    id = var.name
+  }
+
+  byte_length = 4
 }
 
 resource "aws_db_subnet_group" "this" {
@@ -126,15 +141,9 @@ resource "aws_rds_cluster_instance" "this" {
   tags = var.tags
 }
 
-resource "random_id" "snapshot_identifier" {
-  count = var.create_cluster ? 1 : 0
-
-  keepers = {
-    id = var.name
-  }
-
-  byte_length = 4
-}
+################################################################################
+# Enhanced Monitoring
+################################################################################
 
 data "aws_iam_policy_document" "monitoring_rds_assume_role" {
   statement {
@@ -150,10 +159,16 @@ data "aws_iam_policy_document" "monitoring_rds_assume_role" {
 resource "aws_iam_role" "rds_enhanced_monitoring" {
   count = var.create_cluster && var.create_monitoring_role && var.monitoring_interval > 0 ? 1 : 0
 
-  name               = "rds-enhanced-monitoring-${var.name}"
-  assume_role_policy = data.aws_iam_policy_document.monitoring_rds_assume_role.json
+  name        = local.iam_role_name
+  name_prefix = local.iam_role_name_prefix
+  description = var.iam_role_description
+  path        = var.iam_role_path
 
-  permissions_boundary = var.permissions_boundary
+  assume_role_policy    = data.aws_iam_policy_document.monitoring_rds_assume_role.json
+  managed_policy_arns   = var.iam_role_managed_policy_arns
+  permissions_boundary  = var.iam_role_permissions_boundary
+  force_detach_policies = var.iam_role_force_detach_policies
+  max_session_duration  = var.iam_role_max_session_duration
 
   tags = merge(var.tags, {
     Name = local.name
@@ -163,9 +178,13 @@ resource "aws_iam_role" "rds_enhanced_monitoring" {
 resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
   count = var.create_cluster && var.create_monitoring_role && var.monitoring_interval > 0 ? 1 : 0
 
-  role       = local.rds_enhanced_monitoring_name
-  policy_arn = "arn:${var.iam_partition}:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+  role       = aws_iam_role.rds_enhanced_monitoring[0].name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
 }
+
+################################################################################
+# Autoscaling
+################################################################################
 
 resource "aws_appautoscaling_target" "read_replica_count" {
   count = var.create_cluster && var.replica_scale_enabled ? 1 : 0
@@ -198,6 +217,10 @@ resource "aws_appautoscaling_policy" "autoscaling_read_replica_count" {
 
   depends_on = [aws_appautoscaling_target.read_replica_count]
 }
+
+################################################################################
+# Security Group
+################################################################################
 
 resource "aws_security_group" "this" {
   count = var.create_cluster && var.create_security_group ? 1 : 0

--- a/outputs.tf
+++ b/outputs.tf
@@ -54,7 +54,6 @@ output "this_rds_cluster_master_username" {
 output "this_rds_cluster_hosted_zone_id" {
   description = "Route53 hosted zone id of the created cluster"
   value       = element(concat(aws_rds_cluster.this.*.hosted_zone_id, [""]), 0)
-
 }
 
 # aws_rds_cluster_instance
@@ -72,4 +71,20 @@ output "this_rds_cluster_instance_ids" {
 output "this_security_group_id" {
   description = "The security group ID of the cluster"
   value       = local.rds_security_group_id
+}
+
+# Enhanced monitoring role
+output "this_enhanced_monitoring_iam_role_name" {
+  description = "The name of the enhanced monitoring role"
+  value       = element(concat(aws_iam_role.rds_enhanced_monitoring.*.name, [""]), 0)
+}
+
+output "this_enhanced_monitoring_iam_role_arn" {
+  description = "The Amazon Resource Name (ARN) specifying the enhanced monitoring role"
+  value       = element(concat(aws_iam_role.rds_enhanced_monitoring.*.arn, [""]), 0)
+}
+
+output "this_enhanced_monitoring_iam_role_unique_id" {
+  description = "Stable and unique string identifying the enhanced monitoring role"
+  value       = element(concat(aws_iam_role.rds_enhanced_monitoring.*.unique_id, [""]), 0)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "create_cluster" {
-  description = "Controls if RDS cluster should be created (it affects almost all resources)"
+  description = "Whether cluster should be created (it affects almost all resources)"
   type        = bool
   default     = true
 }
@@ -23,7 +23,7 @@ variable "name" {
 }
 
 variable "subnets" {
-  description = "List of subnet IDs to use"
+  description = "List of subnet IDs used by database subnet group created"
   type        = list(string)
   default     = []
 }
@@ -35,7 +35,7 @@ variable "replica_count" {
 }
 
 variable "allowed_security_groups" {
-  description = "A list of Security Group ID's to allow access to."
+  description = "A list of Security Group ID's to allow access to"
   type        = list(string)
   default     = []
 }
@@ -191,7 +191,7 @@ variable "storage_encrypted" {
 }
 
 variable "kms_key_id" {
-  description = "The ARN for the KMS encryption key if one is set to the cluster."
+  description = "The ARN for the KMS encryption key if one is set to the cluster"
   type        = string
   default     = ""
 }
@@ -203,13 +203,13 @@ variable "engine" {
 }
 
 variable "engine_version" {
-  description = "Aurora database engine version."
+  description = "Aurora database engine version"
   type        = string
   default     = "5.6.10a"
 }
 
 variable "enable_http_endpoint" {
-  description = "Whether or not to enable the Data API for a serverless Aurora database engine."
+  description = "Whether or not to enable the Data API for a serverless Aurora database engine"
   type        = bool
   default     = false
 }
@@ -221,25 +221,25 @@ variable "replica_scale_enabled" {
 }
 
 variable "replica_scale_max" {
-  description = "Maximum number of replicas to allow scaling for"
+  description = "Maximum number of read replicas permitted when autoscaling is enabled"
   type        = number
   default     = 0
 }
 
 variable "replica_scale_min" {
-  description = "Minimum number of replicas to allow scaling for"
+  description = "Minimum number of read replicas permitted when autoscaling is enabled"
   type        = number
   default     = 2
 }
 
 variable "replica_scale_cpu" {
-  description = "CPU usage to trigger autoscaling at"
+  description = "CPU threshold which will initiate autoscaling"
   type        = number
   default     = 70
 }
 
 variable "replica_scale_connections" {
-  description = "Average number of connections to trigger autoscaling at. Default value is 70% of db.r4.large's default max_connections"
+  description = "Average number of connections threshold which will initiate autoscaling. Default value is 70% of db.r4.large's default max_connections"
   type        = number
   default     = 700
 }
@@ -263,31 +263,31 @@ variable "tags" {
 }
 
 variable "cluster_tags" {
-  description = "A map of tags to add to only the RDS cluster. Used for AWS Instance Scheduler tagging."
+  description = "A map of tags to add to only the RDS cluster. Used for AWS Instance Scheduler tagging"
   type        = map(string)
   default     = {}
 }
 
 variable "performance_insights_enabled" {
-  description = "Specifies whether Performance Insights is enabled or not."
+  description = "Specifies whether Performance Insights is enabled or not"
   type        = bool
   default     = false
 }
 
 variable "performance_insights_kms_key_id" {
-  description = "The ARN for the KMS key to encrypt Performance Insights data."
+  description = "The ARN for the KMS key to encrypt Performance Insights data"
   type        = string
   default     = ""
 }
 
 variable "iam_database_authentication_enabled" {
-  description = "Specifies whether IAM Database authentication should be enabled or not. Not all versions and instances are supported. Refer to the AWS documentation to see which versions are supported."
+  description = "Specifies whether IAM Database authentication should be enabled or not. Not all versions and instances are supported. Refer to the AWS documentation to see which versions are supported"
   type        = bool
   default     = false
 }
 
 variable "enabled_cloudwatch_logs_exports" {
-  description = "List of log types to export to cloudwatch"
+  description = "List of log types to export to cloudwatch - `audit`, `error`, `general`, `slowquery`, `postgresql`"
   type        = list(string)
   default     = []
 }
@@ -299,19 +299,19 @@ variable "global_cluster_identifier" {
 }
 
 variable "engine_mode" {
-  description = "The database engine mode. Valid values: global, parallelquery, provisioned, serverless, multimaster."
+  description = "The database engine mode. Valid values: global, parallelquery, provisioned, serverless, multimaster"
   type        = string
   default     = "provisioned"
 }
 
 variable "replication_source_identifier" {
-  description = "ARN of a source DB cluster or DB instance if this DB cluster is to be created as a Read Replica."
+  description = "ARN of a source DB cluster or DB instance if this DB cluster is to be created as a Read Replica"
   type        = string
   default     = ""
 }
 
 variable "source_region" {
-  description = "The source region for an encrypted replica DB cluster."
+  description = "The source region for an encrypted replica DB cluster"
   type        = string
   default     = ""
 }
@@ -329,31 +329,31 @@ variable "db_subnet_group_name" {
 }
 
 variable "predefined_metric_type" {
-  description = "The metric type to scale on. Valid values are RDSReaderAverageCPUUtilization and RDSReaderAverageDatabaseConnections."
+  description = "The metric type to scale on. Valid values are RDSReaderAverageCPUUtilization and RDSReaderAverageDatabaseConnections"
   type        = string
   default     = "RDSReaderAverageCPUUtilization"
 }
 
 variable "backtrack_window" {
-  description = "The target backtrack window, in seconds. Only available for aurora engine currently. To disable backtracking, set this value to 0. Defaults to 0. Must be between 0 and 259200 (72 hours)"
+  description = "The target backtrack window, in seconds. Only available for aurora engine currently. To disable backtracking, set this value to 0. Must be between 0 and 259200 (72 hours)"
   type        = number
   default     = 0
 }
 
 variable "copy_tags_to_snapshot" {
-  description = "Copy all Cluster tags to snapshots."
+  description = "Copy all Cluster tags to snapshots"
   type        = bool
   default     = false
 }
 
 variable "iam_roles" {
-  description = "A List of ARNs for the IAM roles to associate to the RDS Cluster."
+  description = "A List of ARNs for the IAM roles to associate to the RDS Cluster"
   type        = list(string)
   default     = []
 }
 
 variable "security_group_description" {
-  description = "The description of the security group. If value is set to empty string it will contain cluster name in the description."
+  description = "The description of the security group. If value is set to empty string it will contain cluster name in the description"
   type        = string
   default     = "Managed by Terraform"
 }
@@ -365,13 +365,13 @@ variable "ca_cert_identifier" {
 }
 
 variable "instances_parameters" {
-  description = "Customized instance settings. Supported keys: instance_name, instance_type, instance_promotion_tier, publicly_accessible"
+  description = "Customized instance settings. Supported keys: `instance_name`, `instance_type`, `instance_promotion_tier`, `publicly_accessible`"
   type        = list(map(string))
   default     = []
 }
 
 variable "s3_import" {
-  description = "Restore from a Percona Xtrabackup in S3 (only MySQL is supported)"
+  description = "Configuration map used to restore from a Percona Xtrabackup in S3 (only MySQL is supported)"
   type        = map(string)
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -10,12 +10,6 @@ variable "create_security_group" {
   default     = true
 }
 
-variable "create_random_password" {
-  description = "Whether to create random password for RDS primary cluster"
-  type        = bool
-  default     = true
-}
-
 variable "name" {
   description = "Name used across resources created"
   type        = string
@@ -82,8 +76,14 @@ variable "username" {
   default     = "root"
 }
 
+variable "create_random_password" {
+  description = "Whether to create random password for RDS primary cluster"
+  type        = bool
+  default     = true
+}
+
 variable "password" {
-  description = "Master DB password"
+  description = "Master DB password. Note - when specifying a value here, 'create_random_password' should be set to `false`"
   type        = string
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "create_random_password" {
 }
 
 variable "name" {
-  description = "Name given resources"
+  description = "Name used across resources created"
   type        = string
   default     = ""
 }
@@ -140,24 +140,6 @@ variable "apply_immediately" {
   description = "Determines whether or not any DB modifications are applied immediately, or during the maintenance window"
   type        = bool
   default     = false
-}
-
-variable "iam_partition" {
-  description = "IAM Partition to use when generating ARN's. For most regions this can be left at default. China/Govcloud use different partitions"
-  type        = string
-  default     = "aws"
-}
-
-variable "monitoring_role_arn" {
-  description = "IAM role for RDS to send enhanced monitoring metrics to CloudWatch"
-  type        = string
-  default     = ""
-}
-
-variable "create_monitoring_role" {
-  description = "Whether to create the IAM role for RDS enhanced monitoring"
-  type        = bool
-  default     = true
 }
 
 variable "monitoring_interval" {
@@ -376,12 +358,6 @@ variable "security_group_description" {
   default     = "Managed by Terraform"
 }
 
-variable "permissions_boundary" {
-  description = "The ARN of the policy that is used to set the permissions boundary for the role."
-  type        = string
-  default     = null
-}
-
 variable "ca_cert_identifier" {
   description = "The identifier of the CA certificate for the DB instance"
   type        = string
@@ -397,5 +373,66 @@ variable "instances_parameters" {
 variable "s3_import" {
   description = "Restore from a Percona Xtrabackup in S3 (only MySQL is supported)"
   type        = map(string)
+  default     = null
+}
+
+# Enhanced monitoring role
+variable "create_monitoring_role" {
+  description = "Whether to create the IAM role for RDS enhanced monitoring"
+  type        = bool
+  default     = true
+}
+
+variable "monitoring_role_arn" {
+  description = "IAM role used by RDS to send enhanced monitoring metrics to CloudWatch"
+  type        = string
+  default     = ""
+}
+
+variable "iam_role_name" {
+  description = "Friendly name of the role"
+  type        = string
+  default     = null
+}
+
+variable "iam_role_use_name_prefix" {
+  description = "Whether to use `iam_role_name` as is or create a unique name beginning with the `iam_role_name` as the prefix"
+  type        = bool
+  default     = false
+}
+
+variable "iam_role_description" {
+  description = "Description of the role"
+  type        = string
+  default     = null
+}
+
+variable "iam_role_path" {
+  description = "Path to the role"
+  type        = string
+  default     = null
+}
+
+variable "iam_role_managed_policy_arns" {
+  description = "Set of exclusive IAM managed policy ARNs to attach to the IAM role"
+  type        = list(string)
+  default     = null
+}
+
+variable "iam_role_permissions_boundary" {
+  description = "The ARN of the policy that is used to set the permissions boundary for the role"
+  type        = string
+  default     = null
+}
+
+variable "iam_role_force_detach_policies" {
+  description = "Whether to force detaching any policies the role has before destroying it"
+  type        = bool
+  default     = null
+}
+
+variable "iam_role_max_session_duration" {
+  description = "Maximum session duration (in seconds) that you want to set for the role"
+  type        = number
   default     = null
 }


### PR DESCRIPTION
## Description
- add all attributes and some outputs for enhanced monitoring IAM role
- update `autoscaling` example for changes made here
- update variable descriptions (semantic corrects)

## Motivation and Context
- expose all attributes for configuring the enhanced monitoring IAM role

Closes #93
Closes #153 
Closes #196

## Breaking Changes
- Yes - users will need to make the following changes to

```hcl
	# Remove the following parameter from the module configuration
	# Functionality is stil maintained and provided by a data source so this value no longer needs to be set 
	# ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition)
	iam_partition = "aws-gov"
	
	# Change `permissions_boundary` to `iam_role_permissions_boundary`
	permissions_boundary = "arn:aws:..." -> iam_role_permissions_boundary = "arn:aws:..."
```

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- Test/verification stesp:
	- Deploy `examples/autoscaling` as currently defined on `master` branch
	- Switch to this branch and comment out lines 57-61 of `examples/autoscaling` (+outputs - this is 1:1 compared to what is currently on `master`)
	- Run `terraform plan` -> no changes detected
	- Uncomment lines 57-61 and outputs
	- Run `terraform apply`
	- Verify changes match desired outcome