### PR TITLE
fix: Bump AWS provider version

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,14 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.26 |
-| aws | >= 3.8 |
+| aws | >= 3.30 |
 | random | >= 2.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.8 |
+| aws | >= 3.30 |
 | random | >= 2.2 |
 
 ## Modules

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.8"
+      version = ">= 3.30"
     }
 
     random = {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Bump required AWS provider version to v3.30

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`managed_policy_arns` parameter for the `aws_iam_role` resource was only added in AWS provider v3.29.1. 
Not requiring this minimum version could cause `Unsupported argument` error when the provider is locked to older version.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
Not known

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
