### PR TITLE
fix: when `engine_mode` is `serverless`, set `engine_version` to `null`

### DIFF
--- a/examples/serverless/main.tf
+++ b/examples/serverless/main.tf
@@ -40,7 +40,6 @@ module "aurora_postgresql" {
   name              = "${local.name}-postgresql"
   engine            = "aurora-postgresql"
   engine_mode       = "serverless"
-  engine_version    = null
   storage_encrypted = true
 
   vpc_id                = module.vpc.vpc_id
@@ -93,7 +92,6 @@ module "aurora_mysql" {
   name              = "${local.name}-mysql"
   engine            = "aurora-mysql"
   engine_mode       = "serverless"
-  engine_version    = null
   storage_encrypted = true
 
   vpc_id                = module.vpc.vpc_id

--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,7 @@ resource "aws_rds_cluster" "this" {
   source_region                       = var.source_region
   engine                              = var.engine
   engine_mode                         = var.engine_mode
-  engine_version                      = var.engine_version
+  engine_version                      = var.engine_mode == "serverless" ? null : var.engine_version
   allow_major_version_upgrade         = var.allow_major_version_upgrade
   enable_http_endpoint                = var.enable_http_endpoint
   kms_key_id                          = var.kms_key_id


### PR DESCRIPTION
## Description
- when `engine_mode` is `serverless`, set `engine_version` to `null`

## Motivation and Context
Closes #160 
Closes #161

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
	  - updated and validated `serverless` example
