### PR TITLE
feat: Additional tags for security group

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ No Modules.
 | s3\_import | Configuration map used to restore from a Percona Xtrabackup in S3 (only MySQL is supported) | `map(string)` | `null` | no |
 | scaling\_configuration | Map of nested attributes with scaling properties. Only valid when engine\_mode is set to `serverless` | `map(string)` | `{}` | no |
 | security\_group\_description | The description of the security group. If value is set to empty string it will contain cluster name in the description | `string` | `"Managed by Terraform"` | no |
+| security\_group\_tags | A map of tags to add to created security group, in addition to the other tags | `map(string)` | `{}` | no |
 | skip\_final\_snapshot | Should a final snapshot be created on cluster destroy | `bool` | `false` | no |
 | snapshot\_identifier | DB snapshot to create this database from | `string` | `null` | no |
 | source\_region | The source region for an encrypted replica DB cluster | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ No Modules.
 | s3\_import | Configuration map used to restore from a Percona Xtrabackup in S3 (only MySQL is supported) | `map(string)` | `null` | no |
 | scaling\_configuration | Map of nested attributes with scaling properties. Only valid when engine\_mode is set to `serverless` | `map(string)` | `{}` | no |
 | security\_group\_description | The description of the security group. If value is set to empty string it will contain cluster name in the description | `string` | `"Managed by Terraform"` | no |
-| security\_group\_tags | A map of tags to add to created security group, in addition to the other tags | `map(string)` | `{}` | no |
+| security\_group\_tags | Additional tags for the security group | `map(string)` | `{}` | no |
 | skip\_final\_snapshot | Should a final snapshot be created on cluster destroy | `bool` | `false` | no |
 | snapshot\_identifier | DB snapshot to create this database from | `string` | `null` | no |
 | source\_region | The source region for an encrypted replica DB cluster | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -230,7 +230,7 @@ resource "aws_security_group" "this" {
 
   description = var.security_group_description == "" ? "Control traffic to/from RDS Aurora ${var.name}" : var.security_group_description
 
-  tags = merge(var.tags, {
+  tags = merge(var.tags, var.security_group_tags, {
     Name = local.name
   })
 }

--- a/variables.tf
+++ b/variables.tf
@@ -269,7 +269,7 @@ variable "cluster_tags" {
 }
 
 variable "security_group_tags" {
-  description = "A map of tags to add to created security group, in addition to the other tags."
+  description = "Additional tags for the security group"
   type        = map(string)
   default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -268,6 +268,12 @@ variable "cluster_tags" {
   default     = {}
 }
 
+variable "security_group_tags" {
+  description = "A map of tags to add to created security group, in addition to the other tags."
+  type        = map(string)
+  default     = {}
+}
+
 variable "performance_insights_enabled" {
   description = "Specifies whether Performance Insights is enabled or not"
   type        = bool


### PR DESCRIPTION
## Description
Provide an additional set of tags for the security group created

## Motivation and Context
Needed for enterprise security audits

## Breaking Changes
None

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- Verified that providing this value does tag the security group correctly.
- Works like cluster_tags