### PR TITLE
fix: Don't use instance_type_replica for main replica

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -116,7 +116,7 @@ resource "aws_rds_cluster_instance" "this" {
   cluster_identifier              = element(concat(aws_rds_cluster.this.*.id, [""]), 0)
   engine                          = var.engine
   engine_version                  = var.engine_version
-  instance_class                  = try(lookup(var.instances_parameters[count.index], "instance_type"), coalesce(var.instance_type_replica, var.instance_type))
+  instance_class                  = try(lookup(var.instances_parameters[count.index], "instance_type"), count.index > 0 ? coalesce(var.instance_type_replica, var.instance_type) : var.instance_type)
   publicly_accessible             = try(lookup(var.instances_parameters[count.index], "publicly_accessible"), var.publicly_accessible)
   db_subnet_group_name            = local.db_subnet_group_name
   db_parameter_group_name         = var.db_parameter_group_name


### PR DESCRIPTION
## Motivation and Context
https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/210


## How Has This Been Tested?
- [X] I have tested and validated these changes using all of the provided `examples/*` projects
- [X] Created a cluster with different instance types
