### PR TITLE
fix: set backup and maintenance windows to `null` when using serverless mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.48.0
+    rev: v1.49.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/main.tf
+++ b/main.tf
@@ -67,8 +67,8 @@ resource "aws_rds_cluster" "this" {
   skip_final_snapshot                 = var.skip_final_snapshot
   deletion_protection                 = var.deletion_protection
   backup_retention_period             = var.backup_retention_period
-  preferred_backup_window             = var.preferred_backup_window
-  preferred_maintenance_window        = var.preferred_maintenance_window
+  preferred_backup_window             = var.engine_mode == "serverless" ? null : var.preferred_backup_window
+  preferred_maintenance_window        = var.engine_mode == "serverless" ? null : var.preferred_maintenance_window
   port                                = local.port
   db_subnet_group_name                = local.db_subnet_group_name
   vpc_security_group_ids              = compact(concat(aws_security_group.this.*.id, var.vpc_security_group_ids))


### PR DESCRIPTION
## Description
- set backup and maintenance windows to `null` when using serverless mode

## Motivation and Context
- Closes #167

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- validated using serverless example
