### PR TITLE
fix: mark sensitive outputs to support Terraform 0.15.x

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.49.0
+    rev: v1.50.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -2,14 +2,6 @@
 
 Terraform module which creates RDS Aurora resources on AWS.
 
-These types of resources are supported:
-
-- [RDS Cluster](https://www.terraform.io/docs/providers/aws/r/rds_cluster.html)
-- [RDS Cluster Instance](https://www.terraform.io/docs/providers/aws/r/rds_cluster_instance.html)
-- [DB Subnet Group](https://www.terraform.io/docs/providers/aws/r/db_subnet_group.html)
-- [Application AutoScaling Policy](https://www.terraform.io/docs/providers/aws/r/appautoscaling_policy.html)
-- [Application AutoScaling Target](https://www.terraform.io/docs/providers/aws/r/appautoscaling_target.html)
-
 ## Available features
 
 - Autoscaling of read-replicas (based on CPU utilization)

--- a/examples/autoscaling/outputs.tf
+++ b/examples/autoscaling/outputs.tf
@@ -38,6 +38,7 @@ output "this_rds_cluster_port" {
 output "this_rds_cluster_master_username" {
   description = "The master username"
   value       = module.aurora.this_rds_cluster_master_username
+  sensitive   = true
 }
 
 # aws_rds_cluster_instance

--- a/examples/custom_instance_settings/outputs.tf
+++ b/examples/custom_instance_settings/outputs.tf
@@ -38,6 +38,7 @@ output "this_rds_cluster_port" {
 output "this_rds_cluster_master_username" {
   description = "The master username"
   value       = module.aurora.this_rds_cluster_master_username
+  sensitive   = true
 }
 
 # aws_rds_cluster_instance

--- a/examples/mysql/outputs.tf
+++ b/examples/mysql/outputs.tf
@@ -38,6 +38,7 @@ output "this_rds_cluster_port" {
 output "this_rds_cluster_master_username" {
   description = "The master username"
   value       = module.aurora.this_rds_cluster_master_username
+  sensitive   = true
 }
 
 # aws_rds_cluster_instance

--- a/examples/postgresql/outputs.tf
+++ b/examples/postgresql/outputs.tf
@@ -38,6 +38,7 @@ output "this_rds_cluster_port" {
 output "this_rds_cluster_master_username" {
   description = "The master username"
   value       = module.aurora.this_rds_cluster_master_username
+  sensitive   = true
 }
 
 # aws_rds_cluster_instance

--- a/examples/s3_import/outputs.tf
+++ b/examples/s3_import/outputs.tf
@@ -38,6 +38,7 @@ output "this_rds_cluster_port" {
 output "this_rds_cluster_master_username" {
   description = "The master username"
   value       = module.aurora.this_rds_cluster_master_username
+  sensitive   = true
 }
 
 # aws_rds_cluster_instance

--- a/examples/serverless/outputs.tf
+++ b/examples/serverless/outputs.tf
@@ -42,6 +42,7 @@ output "postgresql_rds_cluster_port" {
 output "postgresql_rds_cluster_master_username" {
   description = "The master username"
   value       = module.aurora_postgresql.this_rds_cluster_master_username
+  sensitive   = true
 }
 
 # aws_rds_cluster_instance

--- a/outputs.tf
+++ b/outputs.tf
@@ -49,6 +49,7 @@ output "this_rds_cluster_port" {
 output "this_rds_cluster_master_username" {
   description = "The master username"
   value       = element(concat(aws_rds_cluster.this.*.master_username, [""]), 0)
+  sensitive   = true
 }
 
 output "this_rds_cluster_hosted_zone_id" {


### PR DESCRIPTION
## Description
- mark sensitive outputs to support Terraform 0.15.x

## Motivation and Context
- Closes #212

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- Tested on `examples/postgresql` and checked with just plans on remaining examples
