### PR TITLE
chore: add output for cluster instance `db_resource_id` output list

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ No modules.
 | <a name="output_rds_cluster_engine_version"></a> [rds\_cluster\_engine\_version](#output\_rds\_cluster\_engine\_version) | The cluster engine version |
 | <a name="output_rds_cluster_hosted_zone_id"></a> [rds\_cluster\_hosted\_zone\_id](#output\_rds\_cluster\_hosted\_zone\_id) | Route53 hosted zone id of the created cluster |
 | <a name="output_rds_cluster_id"></a> [rds\_cluster\_id](#output\_rds\_cluster\_id) | The ID of the cluster |
+| <a name="output_rds_cluster_instance_dbi_resource_ids"></a> [rds\_cluster\_instance\_dbi\_resource\_ids](#output\_rds\_cluster\_instance\_dbi\_resource\_ids) | A list of all the region-unique, immutable identifiers for the DB instances |
 | <a name="output_rds_cluster_instance_endpoints"></a> [rds\_cluster\_instance\_endpoints](#output\_rds\_cluster\_instance\_endpoints) | A list of all cluster instance endpoints |
 | <a name="output_rds_cluster_instance_ids"></a> [rds\_cluster\_instance\_ids](#output\_rds\_cluster\_instance\_ids) | A list of all cluster instance ids |
 | <a name="output_rds_cluster_master_password"></a> [rds\_cluster\_master\_password](#output\_rds\_cluster\_master\_password) | The master password |

--- a/examples/mysql/README.md
+++ b/examples/mysql/README.md
@@ -56,6 +56,7 @@ No inputs.
 | <a name="output_rds_cluster_database_name"></a> [rds\_cluster\_database\_name](#output\_rds\_cluster\_database\_name) | Name for an automatically created database on cluster creation |
 | <a name="output_rds_cluster_endpoint"></a> [rds\_cluster\_endpoint](#output\_rds\_cluster\_endpoint) | The cluster endpoint |
 | <a name="output_rds_cluster_id"></a> [rds\_cluster\_id](#output\_rds\_cluster\_id) | The ID of the cluster |
+| <a name="output_rds_cluster_instance_dbi_resource_ids"></a> [rds\_cluster\_instance\_dbi\_resource\_ids](#output\_rds\_cluster\_instance\_dbi\_resource\_ids) | A list of all the region-unique, immutable identifiers for the DB instances |
 | <a name="output_rds_cluster_instance_endpoints"></a> [rds\_cluster\_instance\_endpoints](#output\_rds\_cluster\_instance\_endpoints) | A list of all cluster instance endpoints |
 | <a name="output_rds_cluster_instance_ids"></a> [rds\_cluster\_instance\_ids](#output\_rds\_cluster\_instance\_ids) | A list of all cluster instance ids |
 | <a name="output_rds_cluster_master_password"></a> [rds\_cluster\_master\_password](#output\_rds\_cluster\_master\_password) | The master password |

--- a/examples/mysql/outputs.tf
+++ b/examples/mysql/outputs.tf
@@ -52,6 +52,11 @@ output "rds_cluster_instance_ids" {
   value       = module.aurora.rds_cluster_instance_ids
 }
 
+output "rds_cluster_instance_dbi_resource_ids" {
+  description = "A list of all the region-unique, immutable identifiers for the DB instances"
+  value       = module.aurora.rds_cluster_instance_dbi_resource_ids
+}
+
 # aws_security_group
 output "security_group_id" {
   description = "The security group ID of the cluster"

--- a/examples/postgresql/README.md
+++ b/examples/postgresql/README.md
@@ -56,6 +56,7 @@ No inputs.
 | <a name="output_rds_cluster_database_name"></a> [rds\_cluster\_database\_name](#output\_rds\_cluster\_database\_name) | Name for an automatically created database on cluster creation |
 | <a name="output_rds_cluster_endpoint"></a> [rds\_cluster\_endpoint](#output\_rds\_cluster\_endpoint) | The cluster endpoint |
 | <a name="output_rds_cluster_id"></a> [rds\_cluster\_id](#output\_rds\_cluster\_id) | The ID of the cluster |
+| <a name="output_rds_cluster_instance_dbi_resource_ids"></a> [rds\_cluster\_instance\_dbi\_resource\_ids](#output\_rds\_cluster\_instance\_dbi\_resource\_ids) | A list of all the region-unique, immutable identifiers for the DB instances |
 | <a name="output_rds_cluster_instance_endpoints"></a> [rds\_cluster\_instance\_endpoints](#output\_rds\_cluster\_instance\_endpoints) | A list of all cluster instance endpoints |
 | <a name="output_rds_cluster_instance_ids"></a> [rds\_cluster\_instance\_ids](#output\_rds\_cluster\_instance\_ids) | A list of all cluster instance ids |
 | <a name="output_rds_cluster_master_password"></a> [rds\_cluster\_master\_password](#output\_rds\_cluster\_master\_password) | The master password |

--- a/examples/postgresql/outputs.tf
+++ b/examples/postgresql/outputs.tf
@@ -52,6 +52,11 @@ output "rds_cluster_instance_ids" {
   value       = module.aurora.rds_cluster_instance_ids
 }
 
+output "rds_cluster_instance_dbi_resource_ids" {
+  description = "A list of all the region-unique, immutable identifiers for the DB instances"
+  value       = module.aurora.rds_cluster_instance_dbi_resource_ids
+}
+
 # aws_security_group
 output "security_group_id" {
   description = "The security group ID of the cluster"

--- a/outputs.tf
+++ b/outputs.tf
@@ -68,6 +68,11 @@ output "rds_cluster_instance_ids" {
   value       = aws_rds_cluster_instance.this.*.id
 }
 
+output "rds_cluster_instance_dbi_resource_ids" {
+  description = "A list of all the region-unique, immutable identifiers for the DB instances"
+  value       = aws_rds_cluster_instance.this.*.dbi_resource_id
+}
+
 # aws_security_group
 output "security_group_id" {
   description = "The security group ID of the cluster"


### PR DESCRIPTION
## Description
- add output for cluster instance `db_resource_id` output list

## Motivation and Context
Closes #217 

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
	- Updated `mysql` and `postgresql` examples and validated using `postgresql`
	
```
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

rds_cluster_database_name =
rds_cluster_endpoint = postgresql.cluster-c9zyrpwvxzzr.eu-west-1.rds.amazonaws.com
rds_cluster_id = postgresql
rds_cluster_instance_dbi_resource_ids = [
  "db-J42FV3T47NUY2AFIWGZVF6BOMU",
  "db-DWKBTBWO7MIKOHVPALLNAYS6D4",
]
rds_cluster_instance_endpoints = [
  "postgresql-1.c9zyrpwvxzzr.eu-west-1.rds.amazonaws.com",
  "postgresql-2.c9zyrpwvxzzr.eu-west-1.rds.amazonaws.com",
]
rds_cluster_instance_ids = [
  "postgresql-1",
  "postgresql-2",
]
rds_cluster_master_password = <sensitive>
rds_cluster_master_username = <sensitive>
rds_cluster_port = 5432
rds_cluster_reader_endpoint = postgresql.cluster-ro-c9zyrpwvxzzr.eu-west-1.rds.amazonaws.com
rds_cluster_resource_id = cluster-34OIQAJ4CTMGOSKXIHQGWO6ZDQ
security_group_id = sg-09856d2b8304a2a5d
```
