### PR TITLE
fix: Increase length of generated random password from 10 to 20

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ data "aws_partition" "current" {}
 resource "random_password" "master_password" {
   count = var.create_cluster && var.create_random_password ? 1 : 0
 
-  length  = 10
+  length  = 20
   special = false
 }
 


### PR DESCRIPTION
## Description
This commit increases the generated password length to 20.

## Motivation and Context
When the user passes `create_random_password = true`, we're currently generating a 10 char alphanumeric password (no special characters). That's *much* too short. It opens the db to brute force password cracking. Increasing the length which will firmly shut the door on brute force password cracking attempts.

## Breaking Changes
N/A

## How Has This Been Tested?
