### PR TITLE
Fix: Ignore changes for aws_rds_cluster.this.engine_version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,6 +106,12 @@ resource "aws_rds_cluster" "this" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [
+      engine_version
+    ]
+  }
+
   tags = merge(var.tags, var.cluster_tags)
 }
 


### PR DESCRIPTION
## Description
Ignore lifecycle changes for `aws_rds_cluster.this.engine_version`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix for #228

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None.

## How Has This Been Tested?
Deployed my own example that was erroring out on #228, added this fix, ran `terraform plan` and got `No changes. Infrastructure is up-to-date.` 
