### PR TITLE
chore: Updated README to use version 5 of the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Terraform module which creates RDS Aurora resources on AWS.
 ```hcl
 module "db" {
   source  = "terraform-aws-modules/rds-aurora/aws"
-  version = "~> 3.0"
+  version = "~> 5.0"
 
   name           = "test-aurora-db-postgres96"
   engine         = "aurora-postgresql"
@@ -50,7 +50,7 @@ Sometimes you need to have a way to create RDS Aurora resources conditionally bu
 # This RDS cluster will not be created
 module "db" {
   source  = "terraform-aws-modules/rds-aurora/aws"
-  version = "~> 3.0"
+  version = "~> 5.0"
 
   create_cluster = false
   # ... omitted


### PR DESCRIPTION
Use version 5 of rds-aurora module in the README examples

## Description
Replaced version 3 with version 5

## Motivation and Context
The output values displayed in the README works for version 5 of the module but are different in version 3. This makes confusing for users trying to use this module from terraform registry for example as the specified output values can't be found.
