### PR TITLE
feat: Add security group egress rule support, fix documentation links

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.52.0
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.55.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -22,7 +22,7 @@ repos:
           - '--args=--only=terraform_required_providers'
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ No modules.
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.cidr_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.default_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [random_id.snapshot_identifier](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_password.master_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [aws_iam_policy_document.monitoring_rds_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -333,6 +334,7 @@ No modules.
 | <a name="input_s3_import"></a> [s3\_import](#input\_s3\_import) | Configuration map used to restore from a Percona Xtrabackup in S3 (only MySQL is supported) | `map(string)` | `null` | no |
 | <a name="input_scaling_configuration"></a> [scaling\_configuration](#input\_scaling\_configuration) | Map of nested attributes with scaling properties. Only valid when `engine_mode` is set to `serverless` | `map(string)` | `{}` | no |
 | <a name="input_security_group_description"></a> [security\_group\_description](#input\_security\_group\_description) | The description of the security group. If value is set to empty string it will contain cluster name in the description | `string` | `null` | no |
+| <a name="input_security_group_egress_rules"></a> [security\_group\_egress\_rules](#input\_security\_group\_egress\_rules) | A map of security group egress rule defintions to add to the security group created | `map(any)` | `{}` | no |
 | <a name="input_security_group_tags"></a> [security\_group\_tags](#input\_security\_group\_tags) | Additional tags for the security group | `map(string)` | `{}` | no |
 | <a name="input_skip_final_snapshot"></a> [skip\_final\_snapshot](#input\_skip\_final\_snapshot) | Determines whether a final snapshot is created before the cluster is deleted. If true is specified, no snapshot is created | `bool` | `null` | no |
 | <a name="input_snapshot_identifier"></a> [snapshot\_identifier](#input\_snapshot\_identifier) | Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -204,12 +204,12 @@ module "cluster" {
 
 ## Examples
 
-- [Autoscaling](examples/autoscaling): A PostgreSQL cluster with enhanced monitoring and autoscaling enabled
-- [Global Cluster](examples/global_cluster): A PostgreSQL global cluster with clusters provisioned in two different region
-- [MySQL](examples/mysql): A simple MySQL cluster
-- [PostgreSQL](examples/postgresql): A simple PostgreSQL cluster
-- [S3 Import](examples/s3_import): A MySQL cluster created from a Percona Xtrabackup stored in S3
-- [Serverless](examples/serverless): Serverless PostgreSQL and MySQL clusters
+- [Autoscaling](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/tree/master/examples/autoscaling): A PostgreSQL cluster with enhanced monitoring and autoscaling enabled
+- [Global Cluster](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/tree/master/examples/global_cluster): A PostgreSQL global cluster with clusters provisioned in two different region
+- [MySQL](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/tree/master/examples/mysql): A simple MySQL cluster
+- [PostgreSQL](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/tree/master/examples/postgresql): A simple PostgreSQL cluster
+- [S3 Import](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/tree/master/examples/s3_import): A MySQL cluster created from a Percona Xtrabackup stored in S3
+- [Serverless](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/tree/master/examples/serverless): Serverless PostgreSQL and MySQL clusters
 
 ## Documentation
 

--- a/examples/postgresql/main.tf
+++ b/examples/postgresql/main.tf
@@ -83,6 +83,12 @@ module "aurora" {
   create_db_subnet_group = false
   create_security_group  = true
   allowed_cidr_blocks    = module.vpc.private_subnets_cidr_blocks
+  security_group_egress_rules = {
+    to_cidrs = {
+      cidr_blocks = ["10.33.0.0/28"]
+      description = "Egress to corporate printer closet"
+    }
+  }
 
   iam_database_authentication_enabled = true
   master_password                     = random_password.master.result

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  port = var.port == "" ? (var.engine == "aurora-postgresql" ? 5432 : 3306) : var.port
+  port = var.port != null ? var.port : (var.engine == "aurora-postgresql" ? 5432 : 3306)
 
   db_subnet_group_name          = var.create_db_subnet_group ? join("", aws_db_subnet_group.this.*.name) : var.db_subnet_group_name
   internal_db_subnet_group_name = try(coalesce(var.db_subnet_group_name, var.name), "")
@@ -8,9 +8,7 @@ locals {
 
   rds_enhanced_monitoring_arn = var.create_monitoring_role ? join("", aws_iam_role.rds_enhanced_monitoring.*.arn) : var.monitoring_role_arn
   rds_security_group_id       = join("", aws_security_group.this.*.id)
-
-
-  is_serverless = var.engine_mode == "serverless"
+  is_serverless               = var.engine_mode == "serverless"
 }
 
 # Ref. https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces
@@ -292,28 +290,48 @@ resource "aws_security_group" "this" {
   })
 }
 
+# TODO - change to map of ingress rules under one resource at next breaking change
 resource "aws_security_group_rule" "default_ingress" {
   count = var.create_cluster && var.create_security_group ? length(var.allowed_security_groups) : 0
 
   description = "From allowed SGs"
 
   type                     = "ingress"
-  from_port                = element(concat(aws_rds_cluster.this.*.port, [""]), 0)
-  to_port                  = element(concat(aws_rds_cluster.this.*.port, [""]), 0)
+  from_port                = local.port
+  to_port                  = local.port
   protocol                 = "tcp"
   source_security_group_id = element(var.allowed_security_groups, count.index)
   security_group_id        = local.rds_security_group_id
 }
 
+# TODO - change to map of ingress rules under one resource at next breaking change
 resource "aws_security_group_rule" "cidr_ingress" {
   count = var.create_cluster && var.create_security_group && length(var.allowed_cidr_blocks) > 0 ? 1 : 0
 
   description = "From allowed CIDRs"
 
   type              = "ingress"
-  from_port         = element(concat(aws_rds_cluster.this.*.port, [""]), 0)
-  to_port           = element(concat(aws_rds_cluster.this.*.port, [""]), 0)
+  from_port         = local.port
+  to_port           = local.port
   protocol          = "tcp"
   cidr_blocks       = var.allowed_cidr_blocks
   security_group_id = local.rds_security_group_id
+}
+
+resource "aws_security_group_rule" "egress" {
+  for_each = var.create_cluster && var.create_security_group ? var.security_group_egress_rules : {}
+
+  # required
+  type              = "egress"
+  from_port         = lookup(each.value, "from_port", local.port)
+  to_port           = lookup(each.value, "to_port", local.port)
+  protocol          = "tcp"
+  security_group_id = local.rds_security_group_id
+
+  # optional
+  cidr_blocks              = lookup(each.value, "cidr_blocks", null)
+  description              = lookup(each.value, "description", null)
+  ipv6_cidr_blocks         = lookup(each.value, "ipv6_cidr_blocks", null)
+  prefix_list_ids          = lookup(each.value, "prefix_list_ids", null)
+  source_security_group_id = lookup(each.value, "source_security_group_id", null)
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  port = var.port != null ? var.port : (var.engine == "aurora-postgresql" ? 5432 : 3306)
+  port = coalesce(var.port, (var.engine == "aurora-postgresql" ? 5432 : 3306))
 
   db_subnet_group_name          = var.create_db_subnet_group ? join("", aws_db_subnet_group.this.*.name) : var.db_subnet_group_name
   internal_db_subnet_group_name = try(coalesce(var.db_subnet_group_name, var.name), "")

--- a/variables.tf
+++ b/variables.tf
@@ -497,3 +497,9 @@ variable "allowed_cidr_blocks" {
   type        = list(string)
   default     = []
 }
+
+variable "security_group_egress_rules" {
+  description = "A map of security group egress rule defintions to add to the security group created"
+  type        = map(any)
+  default     = {}
+}


### PR DESCRIPTION
## Description
- update pre-commit hook versions and URI for HTTPS
- fix links in README by using full URL links instead of relative (closes #38)
- add egress security group rule with new variable to map multiple rules for egress (closes #248)
- fixed small bug in port local variable logic: during last breaking change the `var.part` default value changed from `""` to `null`. this change makes the local variable logic work as intended with the new default value

## Motivation and Context

Closes #38 
Closes #248 

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
	- tested with the `examples/postgresql` example project
