### PR TITLE
fix: Version of serverless aurora database say MySql

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,7 @@ resource "aws_rds_cluster" "this" {
 
   engine                              = var.engine
   engine_mode                         = var.engine_mode
-  engine_version                      = local.is_serverless ? null : var.engine_version
+  engine_version                      = var.engine_version
   allow_major_version_upgrade         = var.allow_major_version_upgrade
   enable_http_endpoint                = var.enable_http_endpoint
   kms_key_id                          = var.kms_key_id


### PR DESCRIPTION
The module does not allow changing the version of databse say MySql for serverless aurora. Thus making this change.

## Description
The module does not allow changing the version of databse say MySql for serverless aurora

## Motivation and Context
Yes it solves the problem by enabling versioning

## Breaking Changes
No it does not have any breaking  changes

## How Has This Been Tested?
yes
