### PR TITLE
fix: SecurityGroup - create_before_destroy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -300,7 +300,7 @@ resource "aws_security_group" "this" {
   description = coalesce(var.security_group_description, "Control traffic to/from RDS Aurora ${var.name}")
 
   tags = merge(var.tags, var.security_group_tags, { Name = var.name })
-  
+
   lifecycle {
     create_before_destroy = true
   }

--- a/main.tf
+++ b/main.tf
@@ -300,6 +300,10 @@ resource "aws_security_group" "this" {
   description = coalesce(var.security_group_description, "Control traffic to/from RDS Aurora ${var.name}")
 
   tags = merge(var.tags, var.security_group_tags, { Name = var.name })
+  
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # TODO - change to map of ingress rules under one resource at next breaking change


### PR DESCRIPTION
## Description
add `create_before_destroy` to the SecurityGroup resource

## Motivation and Context
This fixes AWS API timeouts/errors when changing the name, name_prefix, or description, as described in the [docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#change-of-name-or-name-prefix-value)