### PR TITLE
fix: InvalidParameterCombination: Cannot find version 5.7.12 for aurora-mysql

### DIFF
--- a/examples/mysql/main.tf
+++ b/examples/mysql/main.tf
@@ -46,7 +46,7 @@ module "aurora" {
 
   name           = local.name
   engine         = "aurora-mysql"
-  engine_version = "5.7.12"
+  engine_version = "5.7"
   instances = {
     1 = {
       instance_class      = "db.r5.large"


### PR DESCRIPTION
…rora-mysql" issue. per antonbabenko's suggestion changed engine_version to just major.minor version. "5.7.mysql_aurora.2.10.1" also works

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
