### PR TITLE
Bugfix/Allow-aws-provider-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,409 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+<a name="unreleased"></a>
+## [Unreleased]
+
+
+
+<a name="v2.17.0"></a>
+## [v2.17.0] - 2020-04-11
+
+- feat: Support enable_http_endpoint - Data API ([#117](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/117))
+- Updated postgres example to latest engine_version
+
+
+<a name="v2.16.0"></a>
+## [v2.16.0] - 2020-02-26
+
+- Updated pre-commit-terraform with README
+- Updated pre-commit-terraform with README
+- Adding support for ca_cert_identifier for the upcoming RDS cert update on 5 March 2020 ([#91](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/91)) ([#98](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/98))
+- Added missing type type for allowed_security_groups variable ([#97](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/97))
+
+
+<a name="v2.15.0"></a>
+## [v2.15.0] - 2020-01-28
+
+- Disabled special characters in random_password ([#101](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/101))
+
+
+<a name="v2.14.0"></a>
+## [v2.14.0] - 2020-01-23
+
+- Changed random_id to random_password resource ([#99](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/99))
+
+
+<a name="v2.13.0"></a>
+## [v2.13.0] - 2020-01-23
+
+- Adding version requirements
+
+
+<a name="v2.12.0"></a>
+## [v2.12.0] - 2020-01-23
+
+- Updated pre-commit-terraform to support terraform-docs 0.8
+- Hide sensitive password data from cli output ([#89](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/89))
+
+
+<a name="v2.11.0"></a>
+## [v2.11.0] - 2019-11-29
+
+- Made description of security group backward compatible (and optional) ([#87](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/87))
+- Add security group name and description ([#80](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/80))
+- Updated README
+- Set null as default db_parameter_group_name ([#72](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/72))
+- Support setting aws_rds_cluster iam roles ([#74](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/74))
+- Fix the error when "create_security_group" is false ([#75](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/75))
+- Added support for conditional creation of SG and allowed CIDR blocks ([#71](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/71))
+- Updated README
+- Add option to customise predefined_metric_type ([#66](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/66))
+- Added support for backtrack_window, cross region read replicas, copy_tags_to_snapshots, scaling_configurations ([#70](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/70))
+- Fixes after [#64](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/64) (subnets are optional now), updated pre-commit hooks and docs
+- Add support to use existing subnet group name ([#64](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/64))
+- Fix PostgreSQL example link ([#52](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/52))
+- Support using previously created SG for Aurora cluster - TF 0.12 ([#49](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/49))
+- Add cluster ARN output as 'this_rds_cluster_arn' ([#48](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/48))
+- Upgraded module to support Terraform 0.12 ([#45](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/45))
+
+### 
+
+on ../../modules/aws-rds-aurora/main.tf line 4, in locals:
+
+4:   db_subnet_group_name = var.db_subnet_group_name == "" ?
+aws_db_subnet_group.this[0].name : var.db_subnet_group_name
+
+|----------------
+
+| aws_db_subnet_group.this is empty tuple
+
+when calling import with this module in the configuration.
+
+
+<a name="v1.21.0"></a>
+## [v1.21.0] - 2019-11-28
+
+- Revert "add support for ca_cert_identifier option ([#83](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/83))" ([#85](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/85))
+- add support for ca_cert_identifier option ([#83](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/83))
+- Updated docs
+- Add scaling_configuration ([#63](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/63))
+- Added ability to deploy a cross region Aurora Cluster Read Replica ([#69](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/69))
+- Added backtrack_windows for Aurora ([#57](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/57))
+- Added changelog
+- Added copy_tags_to_snapshot (closes [#60](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/60))
+- Allow the addition of IP-based ingress rules ([#51](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/51))
+- vpc_security_group_ids for Terraform 0.11 ([#46](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/46))
+
+
+<a name="v2.10.0"></a>
+## [v2.10.0] - 2019-11-28
+
+- Add security group name and description ([#80](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/80))
+- Updated README
+- Set null as default db_parameter_group_name ([#72](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/72))
+- Support setting aws_rds_cluster iam roles ([#74](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/74))
+- Fix the error when "create_security_group" is false ([#75](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/75))
+- Added support for conditional creation of SG and allowed CIDR blocks ([#71](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/71))
+- Updated README
+- Add option to customise predefined_metric_type ([#66](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/66))
+- Added support for backtrack_window, cross region read replicas, copy_tags_to_snapshots, scaling_configurations ([#70](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/70))
+- Fixes after [#64](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/64) (subnets are optional now), updated pre-commit hooks and docs
+- Add support to use existing subnet group name ([#64](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/64))
+- Fix PostgreSQL example link ([#52](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/52))
+- Support using previously created SG for Aurora cluster - TF 0.12 ([#49](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/49))
+- Add cluster ARN output as 'this_rds_cluster_arn' ([#48](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/48))
+- Upgraded module to support Terraform 0.12 ([#45](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/45))
+
+### 
+
+on ../../modules/aws-rds-aurora/main.tf line 4, in locals:
+
+4:   db_subnet_group_name = var.db_subnet_group_name == "" ?
+aws_db_subnet_group.this[0].name : var.db_subnet_group_name
+
+|----------------
+
+| aws_db_subnet_group.this is empty tuple
+
+when calling import with this module in the configuration.
+
+
+<a name="v1.20.0"></a>
+## [v1.20.0] - 2019-11-28
+
+- add support for ca_cert_identifier option ([#83](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/83))
+- Updated docs
+- Add scaling_configuration ([#63](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/63))
+- Added ability to deploy a cross region Aurora Cluster Read Replica ([#69](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/69))
+- Added backtrack_windows for Aurora ([#57](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/57))
+- Added changelog
+- Added copy_tags_to_snapshot (closes [#60](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/60))
+- Allow the addition of IP-based ingress rules ([#51](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/51))
+- vpc_security_group_ids for Terraform 0.11 ([#46](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/46))
+
+
+<a name="v2.9.0"></a>
+## [v2.9.0] - 2019-11-08
+
+- Updated README
+- Set null as default db_parameter_group_name ([#72](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/72))
+
+
+<a name="v2.8.0"></a>
+## [v2.8.0] - 2019-11-08
+
+- Support setting aws_rds_cluster iam roles ([#74](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/74))
+
+
+<a name="v2.7.0"></a>
+## [v2.7.0] - 2019-11-08
+
+- Fix the error when "create_security_group" is false ([#75](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/75))
+
+
+<a name="v2.6.0"></a>
+## [v2.6.0] - 2019-09-30
+
+- Added support for conditional creation of SG and allowed CIDR blocks ([#71](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/71))
+
+
+<a name="v2.5.0"></a>
+## [v2.5.0] - 2019-09-30
+
+- Updated README
+- Add option to customise predefined_metric_type ([#66](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/66))
+
+
+<a name="v2.4.0"></a>
+## [v2.4.0] - 2019-09-30
+
+- Added support for backtrack_window, cross region read replicas, copy_tags_to_snapshots, scaling_configurations ([#70](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/70))
+- Fixes after [#64](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/64) (subnets are optional now), updated pre-commit hooks and docs
+- Add support to use existing subnet group name ([#64](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/64))
+- Fix PostgreSQL example link ([#52](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/52))
+- Support using previously created SG for Aurora cluster - TF 0.12 ([#49](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/49))
+- Add cluster ARN output as 'this_rds_cluster_arn' ([#48](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/48))
+- Upgraded module to support Terraform 0.12 ([#45](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/45))
+
+
+<a name="v1.19.0"></a>
+## [v1.19.0] - 2019-09-29
+
+- Updated docs
+- Add scaling_configuration ([#63](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/63))
+
+
+<a name="v1.18.0"></a>
+## [v1.18.0] - 2019-09-29
+
+- Added ability to deploy a cross region Aurora Cluster Read Replica ([#69](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/69))
+
+
+<a name="v1.17.0"></a>
+## [v1.17.0] - 2019-09-28
+
+- Added backtrack_windows for Aurora ([#57](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/57))
+
+
+<a name="v1.16.0"></a>
+## [v1.16.0] - 2019-09-28
+
+- Added changelog
+- Added copy_tags_to_snapshot (closes [#60](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/60))
+- Allow the addition of IP-based ingress rules ([#51](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/51))
+- vpc_security_group_ids for Terraform 0.11 ([#46](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/46))
+
+
+<a name="v2.3.0"></a>
+## [v2.3.0] - 2019-08-29
+
+- Fixes after [#64](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/64) (subnets are optional now), updated pre-commit hooks and docs
+- Add support to use existing subnet group name ([#64](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/64))
+- Fix PostgreSQL example link ([#52](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/52))
+
+
+<a name="v2.2.0"></a>
+## [v2.2.0] - 2019-06-24
+
+- Support using previously created SG for Aurora cluster - TF 0.12 ([#49](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/49))
+- Add cluster ARN output as 'this_rds_cluster_arn' ([#48](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/48))
+- Upgraded module to support Terraform 0.12 ([#45](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/45))
+
+
+<a name="v1.15.0"></a>
+## [v1.15.0] - 2019-06-24
+
+- Allow the addition of IP-based ingress rules ([#51](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/51))
+- vpc_security_group_ids for Terraform 0.11 ([#46](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/46))
+
+
+<a name="v2.1.0"></a>
+## [v2.1.0] - 2019-06-14
+
+- Add cluster ARN output as 'this_rds_cluster_arn' ([#48](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/48))
+- Upgraded module to support Terraform 0.12 ([#45](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/45))
+
+
+<a name="v1.14.0"></a>
+## [v1.14.0] - 2019-06-13
+
+- vpc_security_group_ids for Terraform 0.11 ([#46](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/46))
+
+
+<a name="v2.0.0"></a>
+## [v2.0.0] - 2019-06-11
+
+- Upgraded module to support Terraform 0.12 ([#45](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/45))
+
+
+<a name="v1.13.0"></a>
+## [v1.13.0] - 2019-04-25
+
+- Fixed formatting
+- Remove unused variable identifier_prefix ([#36](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/36))
+- Correct description of replica_scale_min variable ([#37](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/37))
+
+
+<a name="v1.12.0"></a>
+## [v1.12.0] - 2019-03-22
+
+- Fix formatting
+- Feature/rds cluster resource id output ([#31](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/31))
+
+
+<a name="v1.11.0"></a>
+## [v1.11.0] - 2019-03-22
+
+- Fix formatting and string variables
+- add engine_mode and global_cluster_identifier ([#32](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/32))
+
+
+<a name="v1.10.0"></a>
+## [v1.10.0] - 2019-02-28
+
+- Fixed readme
+- add enabled_cloudwatch_logs_exports ([#29](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/29))
+
+
+<a name="v1.9.0"></a>
+## [v1.9.0] - 2019-02-16
+
+- Remove validation
+- Add support for IAM Database authentication
+
+
+<a name="v1.8.0"></a>
+## [v1.8.0] - 2019-01-31
+
+- Updated example with correct allowed_security_groups_count
+- Run pre-commit hooks
+- Hardcode number of allowed_security_groups
+
+
+<a name="v1.7.0"></a>
+## [v1.7.0] - 2019-01-30
+
+- Removing myself from README
+
+
+<a name="v1.6.0"></a>
+## [v1.6.0] - 2019-01-30
+
+- Merge remote-tracking branch 'origin/master' into pr-13
+- Added output for database_name
+- add support for database_name argument
+
+
+<a name="v1.5.0"></a>
+## [v1.5.0] - 2019-01-30
+
+- Merge branch 'master' into support_deletion_protection
+- Added argument deletion_protection
+
+
+<a name="v1.4.0"></a>
+## [v1.4.0] - 2019-01-30
+
+- Removed availability_zones var (closes [#10](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/10))
+
+
+<a name="v1.3.0"></a>
+## [v1.3.0] - 2019-01-30
+
+- Run pre-commit hooks
+- Merge branch 'master' into fix_az
+- Fixed variable for az
+
+
+<a name="v1.1.0"></a>
+## [v1.1.0] - 2019-01-30
+
+- Run pre-commit hooks
+- 3 adjustments: - Avoid description attr on aws_security_group to avoid forcing new instance on changes - Use name-prefix to ensure unique names - Avoid unnecessary name-prefixes
+
+
+<a name="v1.0.0"></a>
+## [v1.0.0] - 2018-12-11
+
+- Updated pre-commit hooks version
+- Fix for: 'count' cannot be computed
+- Added few files
+- Made small changes to be closer to other terraform-aws-modules
+- adding pre commit hooks config
+- updating readme, docs, main.tf etc
+- adding port output
+- adding 3 examples
+- Removing route53 record and all monitoring as requested
+- many fixes and changes
+- Initial commit
+
+
+<a name="v0.0.1"></a>
+## v0.0.1 - 2017-09-26
+
+- Initial commit
+- Initial commit
+
+
+[Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.17.0...HEAD
+[v2.17.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.16.0...v2.17.0
+[v2.16.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.15.0...v2.16.0
+[v2.15.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.14.0...v2.15.0
+[v2.14.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.13.0...v2.14.0
+[v2.13.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.12.0...v2.13.0
+[v2.12.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.11.0...v2.12.0
+[v2.11.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v1.21.0...v2.11.0
+[v1.21.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.10.0...v1.21.0
+[v2.10.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v1.20.0...v2.10.0
+[v1.20.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.9.0...v1.20.0
+[v2.9.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.8.0...v2.9.0
+[v2.8.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.7.0...v2.8.0
+[v2.7.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.6.0...v2.7.0
+[v2.6.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.5.0...v2.6.0
+[v2.5.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.4.0...v2.5.0
+[v2.4.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v1.19.0...v2.4.0
+[v1.19.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v1.18.0...v1.19.0
+[v1.18.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v1.17.0...v1.18.0
+[v1.17.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v1.16.0...v1.17.0
+[v1.16.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.3.0...v1.16.0
+[v2.3.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.2.0...v2.3.0
+[v2.2.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v1.15.0...v2.2.0
+[v1.15.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.1.0...v1.15.0
+[v2.1.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v1.14.0...v2.1.0
+[v1.14.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v2.0.0...v1.14.0
+[v2.0.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v1.13.0...v2.0.0
+[v1.13.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v1.12.0...v1.13.0
+[v1.12.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v1.11.0...v1.12.0
+[v1.11.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v1.10.0...v1.11.0
+[v1.10.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v1.9.0...v1.10.0
+[v1.9.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v1.8.0...v1.9.0
+[v1.8.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v1.7.0...v1.8.0
+[v1.7.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v1.6.0...v1.7.0
+[v1.6.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v1.5.0...v1.6.0
+[v1.5.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v1.4.0...v1.5.0
+[v1.4.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v1.3.0...v1.4.0
+[v1.3.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v1.1.0...v1.3.0
+[v1.1.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v1.0.0...v1.1.0
+[v1.0.0]: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/compare/v0.0.1...v1.0.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,11 @@
-MIT License
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-Copyright (c) 2017 Claranet Ltd
+    http://www.apache.org/licenses/LICENSE-2.0
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: changelog release
+
+changelog:
+	git-chglog -o CHANGELOG.md --next-tag `semtag final -s minor -o`
+
+release:
+	semtag final -s minor

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | apply\_immediately | Determines whether or not any DB modifications are applied immediately, or during the maintenance window | string | `"false"` | no |
 | auto\_minor\_version\_upgrade | Determines whether minor engine upgrades will be performed automatically in the maintenance window | string | `"true"` | no |
 | backup\_retention\_period | How long to keep backups for (in days) | string | `"7"` | no |
+| ca\_cert\_identifier | Which RDS cert to use | string | `"rds-ca-2019"` | no |
 | database\_name | Name for an automatically created database on cluster creation | string | `""` | no |
 | db\_cluster\_parameter\_group\_name | The name of a DB Cluster parameter group to use | string | `"default.aurora5.6"` | no |
 | db\_parameter\_group\_name | The name of a DB parameter group to use | string | `"default.aurora5.6"` | no |

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | storage\_encrypted | Specifies whether the underlying storage layer should be encrypted | string | `"true"` | no |
 | subnets | List of subnet IDs to use | list | n/a | yes |
 | tags | A map of tags to add to all resources. | map | `{}` | no |
-| timeouts | Set how many minutes to wait for DB resources to be created/updated/deleted. | int | `"120"` | no |
+| timeouts | Set how many minutes to wait for DB resources to be created/updated/deleted. | int | `"120m"` | no |
 | username | Master DB username | string | `"root"` | no |
 | vpc\_id | VPC ID | string | n/a | yes |
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | storage\_encrypted | Specifies whether the underlying storage layer should be encrypted | string | `"true"` | no |
 | subnets | List of subnet IDs to use | list | n/a | yes |
 | tags | A map of tags to add to all resources. | map | `{}` | no |
+| timeouts | Set how many minutes to wait for DB resources to be created/updated/deleted. | int | `"120"` | no |
 | username | Master DB username | string | `"root"` | no |
 | vpc\_id | VPC ID | string | n/a | yes |
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | replica\_scale\_enabled | Whether to enable autoscaling for RDS Aurora (MySQL) read replicas | string | `"false"` | no |
 | replica\_scale\_in\_cooldown | Cooldown in seconds before allowing further scaling operations after a scale in | string | `"300"` | no |
 | replica\_scale\_max | Maximum number of replicas to allow scaling for | string | `"0"` | no |
-| replica\_scale\_min | Maximum number of replicas to allow scaling for | string | `"2"` | no |
+| replica\_scale\_min | Minimum number of replicas to allow scaling for | string | `"2"` | no |
 | replica\_scale\_out\_cooldown | Cooldown in seconds before allowing further scaling operations after a scale out | string | `"300"` | no |
 | skip\_final\_snapshot | Should a final snapshot be created on cluster destroy | string | `"false"` | no |
 | snapshot\_identifier | DB snapshot to create this database from | string | `""` | no |

--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | final\_snapshot\_identifier\_prefix | The prefix name to use when creating a final snapshot on cluster destroy, appends a random 8 digits to name to ensure it's unique too. | string | `"final"` | no |
 | global\_cluster\_identifier | The global cluster identifier specified on aws_rds_global_cluster | string | `""` | no |
 | iam\_database\_authentication\_enabled | Specifies whether IAM Database authentication should be enabled or not. Not all versions and instances are supported. Refer to the AWS documentation to see which versions are supported. | string | `"false"` | no |
-| identifier\_prefix | Prefix for cluster and instance identifier | string | `""` | no |
 | instance\_type | Instance type to use | string | n/a | yes |
 | kms\_key\_id | The ARN for the KMS encryption key if one is set to the cluster. | string | `""` | no |
 | monitoring\_interval | The interval (seconds) between points when Enhanced Monitoring metrics are collected | string | `"0"` | no |

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | storage\_encrypted | Specifies whether the underlying storage layer should be encrypted | string | `"true"` | no |
 | subnets | List of subnet IDs to use | list | n/a | yes |
 | tags | A map of tags to add to all resources. | map | `{}` | no |
-| timeouts | Set how many minutes to wait for DB resources to be created/updated/deleted. | int | `"120m"` | no |
+| timeouts | Set how many minutes to wait for DB resources to be created/updated/deleted. | string | `"120m"` | no |
 | username | Master DB username | string | `"root"` | no |
 | vpc\_id | VPC ID | string | n/a | yes |
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ These types of resources are supported:
 * [Application AutoScaling Policy](https://www.terraform.io/docs/providers/aws/r/appautoscaling_policy.html)
 * [Application AutoScaling Target](https://www.terraform.io/docs/providers/aws/r/appautoscaling_target.html)
 
+## Terraform versions
+
+Terraform 0.12. Pin module version to `~> v2.0`. Submit pull-requests to `master` branch.
+
+Terraform 0.11. Pin module version to `~> v1.0`. Submit pull-requests to `terraform011` branch.
+
 ## Available features
 
 - Autoscaling of read-replicas (based on CPU utilization)
@@ -19,19 +25,20 @@ These types of resources are supported:
 
 ```hcl
 module "db" {
-  source                          = "terraform-aws-modules/rds-aurora/aws"
+  source  = "terraform-aws-modules/rds-aurora/aws"
+  version = "~> 2.0"
 
   name                            = "test-aurora-db-postgres96"
 
   engine                          = "aurora-postgresql"
-  engine_version                  = "9.6.3"
+  engine_version                  = "9.6.9"
 
   vpc_id                          = "vpc-12345678"
   subnets                         = ["subnet-12345678", "subnet-87654321"]
 
   replica_count                   = 1
   allowed_security_groups         = ["sg-12345678"]
-  allowed_security_groups_count   = 1
+  allowed_cidr_blocks             = ["10.20.0.0/20"]
   instance_type                   = "db.r4.large"
   storage_encrypted               = true
   apply_immediately               = true
@@ -51,8 +58,9 @@ module "db" {
 
 ## Examples
 
-- [PostgreSQL](examples/postgres): A simple example with VPC and PostgreSQL cluster.
+- [PostgreSQL](examples/postgresql): A simple example with VPC and PostgreSQL cluster.
 - [MySQL](examples/mysql): A simple example with VPC and MySQL cluster.
+- [Serverless](examples/serverless): Serverless PostgreSQL cluster.
 - [Advanced](examples/advanced): A PostgreSQL cluster with enhanced monitoring and autoscaling enabled.
 
 ## Documentation
@@ -60,58 +68,77 @@ module "db" {
 Terraform documentation is generated automatically using [pre-commit hooks](http://www.pre-commit.com/). Follow installation instructions [here](https://pre-commit.com/#install).
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2.0 |
+| random | ~> 2.2 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| allowed\_security\_groups | A list of Security Group ID's to allow access to. | list | `[]` | no |
-| allowed\_security\_groups\_count | The number of Security Groups being added, terraform doesn't let us use length() in a count field | string | `"0"` | no |
-| apply\_immediately | Determines whether or not any DB modifications are applied immediately, or during the maintenance window | string | `"false"` | no |
-| auto\_minor\_version\_upgrade | Determines whether minor engine upgrades will be performed automatically in the maintenance window | string | `"true"` | no |
-| backup\_retention\_period | How long to keep backups for (in days) | string | `"7"` | no |
-| ca\_cert\_identifier | Which RDS cert to use | string | `"rds-ca-2019"` | no |
-| database\_name | Name for an automatically created database on cluster creation | string | `""` | no |
-| db\_cluster\_parameter\_group\_name | The name of a DB Cluster parameter group to use | string | `"default.aurora5.6"` | no |
-| db\_parameter\_group\_name | The name of a DB parameter group to use | string | `"default.aurora5.6"` | no |
-| deletion\_protection | If the DB instance should have deletion protection enabled | string | `"false"` | no |
-| enabled\_cloudwatch\_logs\_exports | List of log types to export to cloudwatch | list | `[]` | no |
-| engine | Aurora database engine type, currently aurora, aurora-mysql or aurora-postgresql | string | `"aurora"` | no |
-| engine\_mode | The database engine mode. Valid values: global, parallelquery, provisioned, serverless. | string | `"provisioned"` | no |
-| engine\_version | Aurora database engine version. | string | `"5.6.10a"` | no |
-| final\_snapshot\_identifier\_prefix | The prefix name to use when creating a final snapshot on cluster destroy, appends a random 8 digits to name to ensure it's unique too. | string | `"final"` | no |
-| global\_cluster\_identifier | The global cluster identifier specified on aws_rds_global_cluster | string | `""` | no |
-| iam\_database\_authentication\_enabled | Specifies whether IAM Database authentication should be enabled or not. Not all versions and instances are supported. Refer to the AWS documentation to see which versions are supported. | string | `"false"` | no |
-| instance\_type | Instance type to use | string | n/a | yes |
-| kms\_key\_id | The ARN for the KMS encryption key if one is set to the cluster. | string | `""` | no |
-| monitoring\_interval | The interval (seconds) between points when Enhanced Monitoring metrics are collected | string | `"0"` | no |
-| name | Name given resources | string | n/a | yes |
-| password | Master DB password | string | `""` | no |
-| performance\_insights\_enabled | Specifies whether Performance Insights is enabled or not. | string | `"false"` | no |
-| performance\_insights\_kms\_key\_id | The ARN for the KMS key to encrypt Performance Insights data. | string | `""` | no |
-| port | The port on which to accept connections | string | `""` | no |
-| preferred\_backup\_window | When to perform DB backups | string | `"02:00-03:00"` | no |
-| preferred\_maintenance\_window | When to perform DB maintenance | string | `"sun:05:00-sun:06:00"` | no |
-| publicly\_accessible | Whether the DB should have a public IP address | string | `"false"` | no |
-| replica\_count | Number of reader nodes to create.  If `replica_scale_enable` is `true`, the value of `replica_scale_min` is used instead. | string | `"1"` | no |
-| replica\_scale\_cpu | CPU usage to trigger autoscaling at | string | `"70"` | no |
-| replica\_scale\_enabled | Whether to enable autoscaling for RDS Aurora (MySQL) read replicas | string | `"false"` | no |
-| replica\_scale\_in\_cooldown | Cooldown in seconds before allowing further scaling operations after a scale in | string | `"300"` | no |
-| replica\_scale\_max | Maximum number of replicas to allow scaling for | string | `"0"` | no |
-| replica\_scale\_min | Minimum number of replicas to allow scaling for | string | `"2"` | no |
-| replica\_scale\_out\_cooldown | Cooldown in seconds before allowing further scaling operations after a scale out | string | `"300"` | no |
-| skip\_final\_snapshot | Should a final snapshot be created on cluster destroy | string | `"false"` | no |
-| snapshot\_identifier | DB snapshot to create this database from | string | `""` | no |
-| storage\_encrypted | Specifies whether the underlying storage layer should be encrypted | string | `"true"` | no |
-| subnets | List of subnet IDs to use | list | n/a | yes |
-| tags | A map of tags to add to all resources. | map | `{}` | no |
-| timeouts | Set how many minutes to wait for DB resources to be created/updated/deleted. | string | `"120m"` | no |
-| username | Master DB username | string | `"root"` | no |
-| vpc\_id | VPC ID | string | n/a | yes |
+|------|-------------|------|---------|:-----:|
+| allowed\_cidr\_blocks | A list of CIDR blocks which are allowed to access the database | `list(string)` | `[]` | no |
+| allowed\_security\_groups | A list of Security Group ID's to allow access to. | `list(string)` | `[]` | no |
+| apply\_immediately | Determines whether or not any DB modifications are applied immediately, or during the maintenance window | `bool` | `false` | no |
+| auto\_minor\_version\_upgrade | Determines whether minor engine upgrades will be performed automatically in the maintenance window | `bool` | `true` | no |
+| backtrack\_window | The target backtrack window, in seconds. Only available for aurora engine currently. To disable backtracking, set this value to 0. Defaults to 0. Must be between 0 and 259200 (72 hours) | `number` | `0` | no |
+| backup\_retention\_period | How long to keep backups for (in days) | `number` | `7` | no |
+| ca\_cert\_identifier | The identifier of the CA certificate for the DB instance | `string` | `"rds-ca-2019"` | no |
+| copy\_tags\_to\_snapshot | Copy all Cluster tags to snapshots. | `bool` | `false` | no |
+| create\_security\_group | Whether to create security group for RDS cluster | `bool` | `true` | no |
+| database\_name | Name for an automatically created database on cluster creation | `string` | `""` | no |
+| db\_cluster\_parameter\_group\_name | The name of a DB Cluster parameter group to use | `string` | n/a | yes |
+| db\_parameter\_group\_name | The name of a DB parameter group to use | `string` | n/a | yes |
+| db\_subnet\_group\_name | The existing subnet group name to use | `string` | `""` | no |
+| deletion\_protection | If the DB instance should have deletion protection enabled | `bool` | `false` | no |
+| enabled\_cloudwatch\_logs\_exports | List of log types to export to cloudwatch | `list(string)` | `[]` | no |
+| engine | Aurora database engine type, currently aurora, aurora-mysql or aurora-postgresql | `string` | `"aurora"` | no |
+| engine\_mode | The database engine mode. Valid values: global, parallelquery, provisioned, serverless. | `string` | `"provisioned"` | no |
+| engine\_version | Aurora database engine version. | `string` | `"5.6.10a"` | no |
+| final\_snapshot\_identifier\_prefix | The prefix name to use when creating a final snapshot on cluster destroy, appends a random 8 digits to name to ensure it's unique too. | `string` | `"final"` | no |
+| global\_cluster\_identifier | The global cluster identifier specified on aws\_rds\_global\_cluster | `string` | `""` | no |
+| iam\_database\_authentication\_enabled | Specifies whether IAM Database authentication should be enabled or not. Not all versions and instances are supported. Refer to the AWS documentation to see which versions are supported. | `bool` | `false` | no |
+| iam\_roles | A List of ARNs for the IAM roles to associate to the RDS Cluster. | `list(string)` | `[]` | no |
+| instance\_type | Instance type to use | `string` | n/a | yes |
+| kms\_key\_id | The ARN for the KMS encryption key if one is set to the cluster. | `string` | `""` | no |
+| monitoring\_interval | The interval (seconds) between points when Enhanced Monitoring metrics are collected | `number` | `0` | no |
+| name | Name given resources | `string` | n/a | yes |
+| password | Master DB password | `string` | `""` | no |
+| performance\_insights\_enabled | Specifies whether Performance Insights is enabled or not. | `bool` | `false` | no |
+| performance\_insights\_kms\_key\_id | The ARN for the KMS key to encrypt Performance Insights data. | `string` | `""` | no |
+| port | The port on which to accept connections | `string` | `""` | no |
+| predefined\_metric\_type | The metric type to scale on. Valid values are RDSReaderAverageCPUUtilization and RDSReaderAverageDatabaseConnections. | `string` | `"RDSReaderAverageCPUUtilization"` | no |
+| preferred\_backup\_window | When to perform DB backups | `string` | `"02:00-03:00"` | no |
+| preferred\_maintenance\_window | When to perform DB maintenance | `string` | `"sun:05:00-sun:06:00"` | no |
+| publicly\_accessible | Whether the DB should have a public IP address | `bool` | `false` | no |
+| replica\_count | Number of reader nodes to create.  If `replica_scale_enable` is `true`, the value of `replica_scale_min` is used instead. | `number` | `1` | no |
+| replica\_scale\_connections | Average number of connections to trigger autoscaling at. Default value is 70% of db.r4.large's default max\_connections | `number` | `700` | no |
+| replica\_scale\_cpu | CPU usage to trigger autoscaling at | `number` | `70` | no |
+| replica\_scale\_enabled | Whether to enable autoscaling for RDS Aurora (MySQL) read replicas | `bool` | `false` | no |
+| replica\_scale\_in\_cooldown | Cooldown in seconds before allowing further scaling operations after a scale in | `number` | `300` | no |
+| replica\_scale\_max | Maximum number of replicas to allow scaling for | `number` | `0` | no |
+| replica\_scale\_min | Minimum number of replicas to allow scaling for | `number` | `2` | no |
+| replica\_scale\_out\_cooldown | Cooldown in seconds before allowing further scaling operations after a scale out | `number` | `300` | no |
+| replication\_source\_identifier | ARN of a source DB cluster or DB instance if this DB cluster is to be created as a Read Replica. | `string` | `""` | no |
+| scaling\_configuration | Map of nested attributes with scaling properties. Only valid when engine\_mode is set to `serverless` | `map(string)` | `{}` | no |
+| security\_group\_description | The description of the security group. If value is set to empty string it will contain cluster name in the description. | `string` | `"Managed by Terraform"` | no |
+| skip\_final\_snapshot | Should a final snapshot be created on cluster destroy | `bool` | `false` | no |
+| snapshot\_identifier | DB snapshot to create this database from | `string` | `""` | no |
+| source\_region | The source region for an encrypted replica DB cluster. | `string` | `""` | no |
+| storage\_encrypted | Specifies whether the underlying storage layer should be encrypted | `bool` | `true` | no |
+| subnets | List of subnet IDs to use | `list(string)` | `[]` | no |
+| tags | A map of tags to add to all resources. | `map(string)` | `{}` | no |
+| username | Master DB username | `string` | `"root"` | no |
+| vpc\_id | VPC ID | `string` | n/a | yes |
+| vpc\_security\_group\_ids | List of VPC security groups to associate to the cluster in addition to the SG we create in this module | `list(string)` | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| this\_rds\_cluster\_arn | The ID of the cluster |
 | this\_rds\_cluster\_database\_name | Name for an automatically created database on cluster creation |
 | this\_rds\_cluster\_endpoint | The cluster endpoint |
 | this\_rds\_cluster\_id | The ID of the cluster |

--- a/examples/advanced/outputs.tf
+++ b/examples/advanced/outputs.tf
@@ -1,53 +1,53 @@
 // aws_rds_cluster
-output "this_rds_cluster_arn" {
-  description = "The ID of the cluster"
-  value       = aws_rds_cluster.this.arn
-}
-
 output "this_rds_cluster_id" {
   description = "The ID of the cluster"
-  value       = aws_rds_cluster.this.id
+  value       = module.aurora.this_rds_cluster_id
 }
 
 output "this_rds_cluster_resource_id" {
   description = "The Resource ID of the cluster"
-  value       = aws_rds_cluster.this.cluster_resource_id
+  value       = module.aurora.this_rds_cluster_resource_id
 }
 
 output "this_rds_cluster_endpoint" {
   description = "The cluster endpoint"
-  value       = aws_rds_cluster.this.endpoint
+  value       = module.aurora.this_rds_cluster_endpoint
 }
 
 output "this_rds_cluster_reader_endpoint" {
   description = "The cluster reader endpoint"
-  value       = aws_rds_cluster.this.reader_endpoint
+  value       = module.aurora.this_rds_cluster_reader_endpoint
 }
 
-// database_name is not set on `aws_rds_cluster` resource if it was not specified, so can't be used in output
 output "this_rds_cluster_database_name" {
   description = "Name for an automatically created database on cluster creation"
-  value       = var.database_name
+  value       = module.aurora.this_rds_cluster_database_name
 }
 
 output "this_rds_cluster_master_password" {
   description = "The master password"
-  value       = aws_rds_cluster.this.master_password
-  sensitive   = true
+  value       = module.aurora.this_rds_cluster_master_password
 }
 
 output "this_rds_cluster_port" {
   description = "The port"
-  value       = aws_rds_cluster.this.port
+  value       = module.aurora.this_rds_cluster_port
 }
 
 output "this_rds_cluster_master_username" {
   description = "The master username"
-  value       = aws_rds_cluster.this.master_username
+  value       = module.aurora.this_rds_cluster_master_username
 }
 
 // aws_rds_cluster_instance
 output "this_rds_cluster_instance_endpoints" {
   description = "A list of all cluster instance endpoints"
-  value       = aws_rds_cluster_instance.this.*.endpoint
+  value       = module.aurora.this_rds_cluster_instance_endpoints
 }
+
+// aws_security_group
+output "this_security_group_id" {
+  description = "The security group ID of the cluster"
+  value       = module.aurora.this_security_group_id
+}
+

--- a/examples/mysql/main.tf
+++ b/examples/mysql/main.tf
@@ -2,30 +2,38 @@ provider "aws" {
   region = "us-east-1"
 }
 
-variable "azs" {
-  type = "list"
-
-  default = [
-    "us-east-1a",
-    "us-east-1b",
-    "us-east-1c",
-  ]
+######################################
+# Data sources to get VPC and subnets
+######################################
+data "aws_vpc" "default" {
+  default = true
 }
 
+data "aws_subnet_ids" "all" {
+  vpc_id = data.aws_vpc.default.id
+}
+
+#############
+# RDS Aurora
+#############
 module "aurora" {
-  source                          = "../../"
-  name                            = "aurora-example"
-  engine                          = "aurora-mysql"
-  engine_version                  = "5.7.12"
-  subnets                         = ["${module.vpc.database_subnets}"]
-  vpc_id                          = "${module.vpc.vpc_id}"
-  replica_count                   = 1
-  instance_type                   = "db.t2.medium"
-  apply_immediately               = true
-  skip_final_snapshot             = true
-  db_parameter_group_name         = "${aws_db_parameter_group.aurora_db_57_parameter_group.id}"
-  db_cluster_parameter_group_name = "${aws_rds_cluster_parameter_group.aurora_57_cluster_parameter_group.id}"
-  enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
+  source                              = "../../"
+  name                                = "aurora-example-mysql"
+  engine                              = "aurora-mysql"
+  engine_version                      = "5.7.12"
+  subnets                             = data.aws_subnet_ids.all.ids
+  vpc_id                              = data.aws_vpc.default.id
+  replica_count                       = 0
+  instance_type                       = "db.t2.medium"
+  apply_immediately                   = true
+  skip_final_snapshot                 = true
+  db_parameter_group_name             = aws_db_parameter_group.aurora_db_57_parameter_group.id
+  db_cluster_parameter_group_name     = aws_rds_cluster_parameter_group.aurora_57_cluster_parameter_group.id
+  iam_database_authentication_enabled = true
+  enabled_cloudwatch_logs_exports     = ["audit", "error", "general", "slowquery"]
+  allowed_cidr_blocks                 = ["10.20.0.0/20", "20.20.0.0/20"]
+
+  create_security_group = true
 }
 
 resource "aws_db_parameter_group" "aurora_db_57_parameter_group" {
@@ -40,47 +48,25 @@ resource "aws_rds_cluster_parameter_group" "aurora_57_cluster_parameter_group" {
   description = "test-aurora-57-cluster-parameter-group"
 }
 
+############################
+# Example of security group
+############################
 resource "aws_security_group" "app_servers" {
-  name        = "app-servers"
+  name_prefix = "app-servers-"
   description = "For application servers"
-  vpc_id      = "${module.vpc.vpc_id}"
+  vpc_id      = data.aws_vpc.default.id
 }
 
 resource "aws_security_group_rule" "allow_access" {
   type                     = "ingress"
-  from_port                = "${module.aurora.this_rds_cluster_port}"
-  to_port                  = "${module.aurora.this_rds_cluster_port}"
+  from_port                = module.aurora.this_rds_cluster_port
+  to_port                  = module.aurora.this_rds_cluster_port
   protocol                 = "tcp"
-  source_security_group_id = "${aws_security_group.app_servers.id}"
-  security_group_id        = "${module.aurora.this_security_group_id}"
+  source_security_group_id = aws_security_group.app_servers.id
+  security_group_id        = module.aurora.this_security_group_id
 }
 
-module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
-  name   = "example"
-  cidr   = "10.0.0.0/16"
-  azs    = ["${var.azs}"]
-
-  private_subnets = [
-    "10.0.1.0/24",
-    "10.0.2.0/24",
-    "10.0.3.0/25",
-  ]
-
-  public_subnets = [
-    "10.0.4.0/24",
-    "10.0.5.0/24",
-    "10.0.6.0/25",
-  ]
-
-  database_subnets = [
-    "10.0.7.0/24",
-    "10.0.8.0/24",
-    "10.0.9.0/25",
-  ]
-}
-
-# IAM Policy for use with iam_database_authentication = true
+# IAM Policy for use with iam_database_authentication_enabled = true
 resource "aws_iam_policy" "aurora_mysql_policy_iam_auth" {
   name = "test-aurora-db-57-policy-iam-auth"
 

--- a/examples/mysql/outputs.tf
+++ b/examples/mysql/outputs.tf
@@ -1,53 +1,53 @@
 // aws_rds_cluster
-output "this_rds_cluster_arn" {
-  description = "The ID of the cluster"
-  value       = aws_rds_cluster.this.arn
-}
-
 output "this_rds_cluster_id" {
   description = "The ID of the cluster"
-  value       = aws_rds_cluster.this.id
+  value       = module.aurora.this_rds_cluster_id
 }
 
 output "this_rds_cluster_resource_id" {
   description = "The Resource ID of the cluster"
-  value       = aws_rds_cluster.this.cluster_resource_id
+  value       = module.aurora.this_rds_cluster_resource_id
 }
 
 output "this_rds_cluster_endpoint" {
   description = "The cluster endpoint"
-  value       = aws_rds_cluster.this.endpoint
+  value       = module.aurora.this_rds_cluster_endpoint
 }
 
 output "this_rds_cluster_reader_endpoint" {
   description = "The cluster reader endpoint"
-  value       = aws_rds_cluster.this.reader_endpoint
+  value       = module.aurora.this_rds_cluster_reader_endpoint
 }
 
-// database_name is not set on `aws_rds_cluster` resource if it was not specified, so can't be used in output
 output "this_rds_cluster_database_name" {
   description = "Name for an automatically created database on cluster creation"
-  value       = var.database_name
+  value       = module.aurora.this_rds_cluster_database_name
 }
 
 output "this_rds_cluster_master_password" {
   description = "The master password"
-  value       = aws_rds_cluster.this.master_password
-  sensitive   = true
+  value       = module.aurora.this_rds_cluster_master_password
 }
 
 output "this_rds_cluster_port" {
   description = "The port"
-  value       = aws_rds_cluster.this.port
+  value       = module.aurora.this_rds_cluster_port
 }
 
 output "this_rds_cluster_master_username" {
   description = "The master username"
-  value       = aws_rds_cluster.this.master_username
+  value       = module.aurora.this_rds_cluster_master_username
 }
 
 // aws_rds_cluster_instance
 output "this_rds_cluster_instance_endpoints" {
   description = "A list of all cluster instance endpoints"
-  value       = aws_rds_cluster_instance.this.*.endpoint
+  value       = module.aurora.this_rds_cluster_instance_endpoints
 }
+
+// aws_security_group
+output "this_security_group_id" {
+  description = "The security group ID of the cluster"
+  value       = module.aurora.this_security_group_id
+}
+

--- a/examples/postgresql/main.tf
+++ b/examples/postgresql/main.tf
@@ -2,80 +2,63 @@ provider "aws" {
   region = "us-east-1"
 }
 
-variable "azs" {
-  type = "list"
-
-  default = [
-    "us-east-1a",
-    "us-east-1b",
-    "us-east-1c",
-  ]
+######################################
+# Data sources to get VPC and subnets
+######################################
+data "aws_vpc" "default" {
+  default = true
 }
 
+data "aws_subnet_ids" "all" {
+  vpc_id = data.aws_vpc.default.id
+}
+
+#############
+# RDS Aurora
+#############
 module "aurora" {
   source                          = "../../"
-  name                            = "aurora-example"
+  name                            = "aurora-example-postgresql"
   engine                          = "aurora-postgresql"
-  engine_version                  = "9.6.3"
-  subnets                         = ["${module.vpc.database_subnets}"]
-  vpc_id                          = "${module.vpc.vpc_id}"
+  engine_version                  = "11.6"
+  subnets                         = data.aws_subnet_ids.all.ids
+  vpc_id                          = data.aws_vpc.default.id
   replica_count                   = 1
   instance_type                   = "db.r4.large"
   apply_immediately               = true
   skip_final_snapshot             = true
-  db_parameter_group_name         = "${aws_db_parameter_group.aurora_db_postgres96_parameter_group.id}"
-  db_cluster_parameter_group_name = "${aws_rds_cluster_parameter_group.aurora_cluster_postgres96_parameter_group.id}"
-  enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
+  db_parameter_group_name         = aws_db_parameter_group.aurora_db_postgres11_parameter_group.id
+  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.aurora_cluster_postgres11_parameter_group.id
+  //  enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
+  security_group_description = ""
 }
 
-resource "aws_db_parameter_group" "aurora_db_postgres96_parameter_group" {
-  name        = "test-aurora-db-postgres96-parameter-group"
-  family      = "aurora-postgresql9.6"
-  description = "test-aurora-db-postgres96-parameter-group"
+resource "aws_db_parameter_group" "aurora_db_postgres11_parameter_group" {
+  name        = "test-aurora-db-postgres11-parameter-group"
+  family      = "aurora-postgresql11"
+  description = "test-aurora-db-postgres11-parameter-group"
 }
 
-resource "aws_rds_cluster_parameter_group" "aurora_cluster_postgres96_parameter_group" {
-  name        = "test-aurora-postgres96-cluster-parameter-group"
-  family      = "aurora-postgresql9.6"
-  description = "test-aurora-postgres96-cluster-parameter-group"
+resource "aws_rds_cluster_parameter_group" "aurora_cluster_postgres11_parameter_group" {
+  name        = "test-aurora-postgres11-cluster-parameter-group"
+  family      = "aurora-postgresql11"
+  description = "test-aurora-postgres11-cluster-parameter-group"
 }
 
+############################
+# Example of security group
+############################
 resource "aws_security_group" "app_servers" {
-  name        = "app-servers"
+  name_prefix = "app-servers-"
   description = "For application servers"
-  vpc_id      = "${module.vpc.vpc_id}"
+  vpc_id      = data.aws_vpc.default.id
 }
 
 resource "aws_security_group_rule" "allow_access" {
   type                     = "ingress"
-  from_port                = "${module.aurora.this_rds_cluster_port}"
-  to_port                  = "${module.aurora.this_rds_cluster_port}"
+  from_port                = module.aurora.this_rds_cluster_port
+  to_port                  = module.aurora.this_rds_cluster_port
   protocol                 = "tcp"
-  source_security_group_id = "${aws_security_group.app_servers.id}"
-  security_group_id        = "${module.aurora.this_security_group_id}"
-}
-
-module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
-  name   = "example"
-  cidr   = "10.0.0.0/16"
-  azs    = ["${var.azs}"]
-
-  private_subnets = [
-    "10.0.1.0/24",
-    "10.0.2.0/24",
-    "10.0.3.0/25",
-  ]
-
-  public_subnets = [
-    "10.0.4.0/24",
-    "10.0.5.0/24",
-    "10.0.6.0/25",
-  ]
-
-  database_subnets = [
-    "10.0.7.0/24",
-    "10.0.8.0/24",
-    "10.0.9.0/25",
-  ]
+  source_security_group_id = aws_security_group.app_servers.id
+  security_group_id        = module.aurora.this_security_group_id
 }

--- a/examples/postgresql/outputs.tf
+++ b/examples/postgresql/outputs.tf
@@ -1,53 +1,54 @@
 // aws_rds_cluster
-output "this_rds_cluster_arn" {
-  description = "The ID of the cluster"
-  value       = aws_rds_cluster.this.arn
-}
-
 output "this_rds_cluster_id" {
   description = "The ID of the cluster"
-  value       = aws_rds_cluster.this.id
+  value       = module.aurora.this_rds_cluster_id
 }
 
 output "this_rds_cluster_resource_id" {
   description = "The Resource ID of the cluster"
-  value       = aws_rds_cluster.this.cluster_resource_id
+  value       = module.aurora.this_rds_cluster_resource_id
 }
 
 output "this_rds_cluster_endpoint" {
   description = "The cluster endpoint"
-  value       = aws_rds_cluster.this.endpoint
+  value       = module.aurora.this_rds_cluster_endpoint
 }
 
 output "this_rds_cluster_reader_endpoint" {
   description = "The cluster reader endpoint"
-  value       = aws_rds_cluster.this.reader_endpoint
+  value       = module.aurora.this_rds_cluster_reader_endpoint
 }
 
-// database_name is not set on `aws_rds_cluster` resource if it was not specified, so can't be used in output
 output "this_rds_cluster_database_name" {
   description = "Name for an automatically created database on cluster creation"
-  value       = var.database_name
+  value       = module.aurora.this_rds_cluster_database_name
 }
 
 output "this_rds_cluster_master_password" {
   description = "The master password"
-  value       = aws_rds_cluster.this.master_password
+  value       = module.aurora.this_rds_cluster_master_password
   sensitive   = true
 }
 
 output "this_rds_cluster_port" {
   description = "The port"
-  value       = aws_rds_cluster.this.port
+  value       = module.aurora.this_rds_cluster_port
 }
 
 output "this_rds_cluster_master_username" {
   description = "The master username"
-  value       = aws_rds_cluster.this.master_username
+  value       = module.aurora.this_rds_cluster_master_username
 }
 
 // aws_rds_cluster_instance
 output "this_rds_cluster_instance_endpoints" {
   description = "A list of all cluster instance endpoints"
-  value       = aws_rds_cluster_instance.this.*.endpoint
+  value       = module.aurora.this_rds_cluster_instance_endpoints
 }
+
+// aws_security_group
+output "this_security_group_id" {
+  description = "The security group ID of the cluster"
+  value       = module.aurora.this_security_group_id
+}
+

--- a/examples/serverless/outputs.tf
+++ b/examples/serverless/outputs.tf
@@ -1,53 +1,53 @@
 // aws_rds_cluster
-output "this_rds_cluster_arn" {
-  description = "The ID of the cluster"
-  value       = aws_rds_cluster.this.arn
-}
-
 output "this_rds_cluster_id" {
   description = "The ID of the cluster"
-  value       = aws_rds_cluster.this.id
+  value       = module.aurora.this_rds_cluster_id
 }
 
 output "this_rds_cluster_resource_id" {
   description = "The Resource ID of the cluster"
-  value       = aws_rds_cluster.this.cluster_resource_id
+  value       = module.aurora.this_rds_cluster_resource_id
 }
 
 output "this_rds_cluster_endpoint" {
   description = "The cluster endpoint"
-  value       = aws_rds_cluster.this.endpoint
+  value       = module.aurora.this_rds_cluster_endpoint
 }
 
 output "this_rds_cluster_reader_endpoint" {
   description = "The cluster reader endpoint"
-  value       = aws_rds_cluster.this.reader_endpoint
+  value       = module.aurora.this_rds_cluster_reader_endpoint
 }
 
-// database_name is not set on `aws_rds_cluster` resource if it was not specified, so can't be used in output
 output "this_rds_cluster_database_name" {
   description = "Name for an automatically created database on cluster creation"
-  value       = var.database_name
+  value       = module.aurora.this_rds_cluster_database_name
 }
 
 output "this_rds_cluster_master_password" {
   description = "The master password"
-  value       = aws_rds_cluster.this.master_password
-  sensitive   = true
+  value       = module.aurora.this_rds_cluster_master_password
 }
 
 output "this_rds_cluster_port" {
   description = "The port"
-  value       = aws_rds_cluster.this.port
+  value       = module.aurora.this_rds_cluster_port
 }
 
 output "this_rds_cluster_master_username" {
   description = "The master username"
-  value       = aws_rds_cluster.this.master_username
+  value       = module.aurora.this_rds_cluster_master_username
 }
 
 // aws_rds_cluster_instance
 output "this_rds_cluster_instance_endpoints" {
   description = "A list of all cluster instance endpoints"
-  value       = aws_rds_cluster_instance.this.*.endpoint
+  value       = module.aurora.this_rds_cluster_instance_endpoints
 }
+
+// aws_security_group
+output "this_security_group_id" {
+  description = "The security group ID of the cluster"
+  value       = module.aurora.this_security_group_id
+}
+

--- a/main.tf
+++ b/main.tf
@@ -43,6 +43,12 @@ resource "aws_rds_cluster" "this" {
 
   enabled_cloudwatch_logs_exports = "${var.enabled_cloudwatch_logs_exports}"
 
+  timeouts {
+    create = "${var.timeouts}"
+    update = "${var.timeouts}"
+    delete = "${var.timeouts}"
+  }
+
   tags = "${var.tags}"
 }
 
@@ -65,6 +71,12 @@ resource "aws_rds_cluster_instance" "this" {
   promotion_tier                  = "${count.index + 1}"
   performance_insights_enabled    = "${var.performance_insights_enabled}"
   performance_insights_kms_key_id = "${var.performance_insights_kms_key_id}"
+
+  timeouts {
+    create = "${var.timeouts}"
+    update = "${var.timeouts}"
+    delete = "${var.timeouts}"
+  }
 
   tags = "${var.tags}"
 }

--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,7 @@ resource "aws_rds_cluster_instance" "this" {
   promotion_tier                  = "${count.index + 1}"
   performance_insights_enabled    = "${var.performance_insights_enabled}"
   performance_insights_kms_key_id = "${var.performance_insights_kms_key_id}"
+  ca_cert_identifier              = "${var.ca_cert_identifier}"
 
   timeouts {
     create = "${var.timeouts}"

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "aws_rds_cluster" "this" {
   preferred_maintenance_window        = "${var.preferred_maintenance_window}"
   port                                = "${local.port}"
   db_subnet_group_name                = "${aws_db_subnet_group.this.name}"
-  vpc_security_group_ids              = "${var.vpc_security_groups}"
+  vpc_security_group_ids              = ["${var.vpc_security_groups}"]
   snapshot_identifier                 = "${var.snapshot_identifier}"
   storage_encrypted                   = "${var.storage_encrypted}"
   apply_immediately                   = "${var.apply_immediately}"

--- a/main.tf
+++ b/main.tf
@@ -1,107 +1,133 @@
 locals {
-  port            = "${var.port == "" ? "${var.engine == "aurora-postgresql" ? "5432" : "3306"}" : var.port}"
-  master_password = "${var.password == "" ? random_id.master_password.b64 : var.password}"
+  port                 = var.port == "" ? var.engine == "aurora-postgresql" ? "5432" : "3306" : var.port
+  master_password      = var.password == "" ? random_password.master_password.result : var.password
+  name = "aurora-${var.name}"
 }
 
+
 # Random string to use as master password unless one is specified
-resource "random_id" "master_password" {
-  byte_length = 10
+resource "random_password" "master_password" {
+  length  = 10
+  special = false
 }
 
 resource "aws_db_subnet_group" "this" {
-  name        = "${var.name}"
-  description = "For Aurora cluster ${var.name}"
-  subnet_ids  = ["${var.subnets}"]
 
-  tags = "${merge(var.tags, map("Name", "aurora-${var.name}"))}"
+  name        = var.name
+  description = "For Aurora cluster ${var.name}"
+  subnet_ids  = var.subnets
+
+  tags = merge(var.tags, {
+    Name = local.name
+  })
+  
 }
 
 resource "aws_rds_cluster" "this" {
-  global_cluster_identifier           = "${var.global_cluster_identifier}"
-  cluster_identifier                  = "${var.name}"
-  engine                              = "${var.engine}"
-  engine_mode                         = "${var.engine_mode}"
-  engine_version                      = "${var.engine_version}"
-  kms_key_id                          = "${var.kms_key_id}"
-  database_name                       = "${var.database_name}"
-  master_username                     = "${var.username}"
-  master_password                     = "${local.master_password}"
+  global_cluster_identifier           = var.global_cluster_identifier
+  cluster_identifier                  = var.name
+  replication_source_identifier       = var.replication_source_identifier
+  source_region                       = var.source_region
+  engine                              = var.engine
+  engine_mode                         = var.engine_mode
+  engine_version                      = var.engine_version
+  enable_http_endpoint                = var.enable_http_endpoint
+  kms_key_id                          = var.kms_key_id
+  database_name                       = var.database_name
+  master_username                     = var.username
+  master_password                     = local.master_password
   final_snapshot_identifier           = "${var.final_snapshot_identifier_prefix}-${var.name}-${random_id.snapshot_identifier.hex}"
-  skip_final_snapshot                 = "${var.skip_final_snapshot}"
-  deletion_protection                 = "${var.deletion_protection}"
-  backup_retention_period             = "${var.backup_retention_period}"
-  preferred_backup_window             = "${var.preferred_backup_window}"
-  preferred_maintenance_window        = "${var.preferred_maintenance_window}"
-  port                                = "${local.port}"
-  db_subnet_group_name                = "${aws_db_subnet_group.this.name}"
-  vpc_security_group_ids              = ["${var.vpc_security_groups}"]
-  snapshot_identifier                 = "${var.snapshot_identifier}"
-  storage_encrypted                   = "${var.storage_encrypted}"
-  apply_immediately                   = "${var.apply_immediately}"
-  db_cluster_parameter_group_name     = "${var.db_cluster_parameter_group_name}"
-  iam_database_authentication_enabled = "${var.iam_database_authentication_enabled}"
+  skip_final_snapshot                 = var.skip_final_snapshot
+  deletion_protection                 = var.deletion_protection
+  backup_retention_period             = var.backup_retention_period
+  preferred_backup_window             = var.preferred_backup_window
+  preferred_maintenance_window        = var.preferred_maintenance_window
+  port                                = local.port
+  db_subnet_group_name                = aws_db_subnet_group.this.name
+  vpc_security_group_ids              = var.vpc_security_groups
+  snapshot_identifier                 = var.snapshot_identifier
+  storage_encrypted                   = var.storage_encrypted
+  apply_immediately                   = var.apply_immediately
+  db_cluster_parameter_group_name     = var.db_cluster_parameter_group_name
+  iam_database_authentication_enabled = var.iam_database_authentication_enabled
+  copy_tags_to_snapshot               = var.copy_tags_to_snapshot
+  iam_roles                           = var.iam_roles
 
-  enabled_cloudwatch_logs_exports = "${var.enabled_cloudwatch_logs_exports}"
+  enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
 
   timeouts {
-    create = "${var.timeouts}"
-    update = "${var.timeouts}"
-    delete = "${var.timeouts}"
+    create = var.timeouts
+    update = var.timeouts
+    delete = var.timeouts
   }
 
-  tags = "${var.tags}"
+  dynamic "scaling_configuration" {
+    for_each = length(keys(var.scaling_configuration)) == 0 ? [] : [
+    var.scaling_configuration]
+
+    content {
+      auto_pause               = lookup(scaling_configuration.value, "auto_pause", null)
+      max_capacity             = lookup(scaling_configuration.value, "max_capacity", null)
+      min_capacity             = lookup(scaling_configuration.value, "min_capacity", null)
+      seconds_until_auto_pause = lookup(scaling_configuration.value, "seconds_until_auto_pause", null)
+      timeout_action           = lookup(scaling_configuration.value, "timeout_action", null)
+    }
+  }
+
+  tags = var.tags
 }
 
 resource "aws_rds_cluster_instance" "this" {
-  count = "${var.replica_scale_enabled ? var.replica_scale_min : var.replica_count}"
+  count = var.replica_scale_enabled ? var.replica_scale_min : var.replica_count
 
   identifier                      = "${var.name}-${count.index + 1}"
-  cluster_identifier              = "${aws_rds_cluster.this.id}"
-  engine                          = "${var.engine}"
-  engine_version                  = "${var.engine_version}"
-  instance_class                  = "${var.instance_type}"
-  publicly_accessible             = "${var.publicly_accessible}"
-  db_subnet_group_name            = "${aws_db_subnet_group.this.name}"
-  db_parameter_group_name         = "${var.db_parameter_group_name}"
-  preferred_maintenance_window    = "${var.preferred_maintenance_window}"
-  apply_immediately               = "${var.apply_immediately}"
-  monitoring_role_arn             = "${var.iam_role_enhanced_monitoring_arn}"
-  monitoring_interval             = "${var.monitoring_interval}"
-  auto_minor_version_upgrade      = "${var.auto_minor_version_upgrade}"
-  promotion_tier                  = "${count.index + 1}"
-  performance_insights_enabled    = "${var.performance_insights_enabled}"
-  performance_insights_kms_key_id = "${var.performance_insights_kms_key_id}"
-  ca_cert_identifier              = "${var.ca_cert_identifier}"
-
+  cluster_identifier              = aws_rds_cluster.this.id
+  engine                          = var.engine
+  engine_version                  = var.engine_version
+  instance_class                  = var.instance_type
+  publicly_accessible             = var.publicly_accessible
+  db_subnet_group_name            = aws_db_subnet_group.this.name
+  db_parameter_group_name         = var.db_parameter_group_name
+  preferred_maintenance_window    = var.preferred_maintenance_window
+  apply_immediately               = var.apply_immediately
+  monitoring_role_arn             = var.iam_role_enhanced_monitoring_arn
+  monitoring_interval             = var.monitoring_interval
+  auto_minor_version_upgrade      = var.auto_minor_version_upgrade
+  promotion_tier                  = count.index + 1
+  performance_insights_enabled    = var.performance_insights_enabled
+  performance_insights_kms_key_id = var.performance_insights_kms_key_id
+  ca_cert_identifier              = var.ca_cert_identifier
+  
   timeouts {
-    create = "${var.timeouts}"
-    update = "${var.timeouts}"
-    delete = "${var.timeouts}"
+    create = var.timeouts
+    update = var.timeouts
+    delete = var.timeouts
   }
 
-  tags = "${var.tags}"
+
+  tags = var.tags
 }
 
 resource "random_id" "snapshot_identifier" {
   keepers = {
-    id = "${var.name}"
+    id = var.name
   }
 
   byte_length = 4
 }
 
 resource "aws_appautoscaling_target" "read_replica_count" {
-  count = "${var.replica_scale_enabled ? 1 : 0}"
+  count = var.replica_scale_enabled ? 1 : 0
 
-  max_capacity       = "${var.replica_scale_max}"
-  min_capacity       = "${var.replica_scale_min}"
+  max_capacity       = var.replica_scale_max
+  min_capacity       = var.replica_scale_min
   resource_id        = "cluster:${aws_rds_cluster.this.cluster_identifier}"
   scalable_dimension = "rds:cluster:ReadReplicaCount"
   service_namespace  = "rds"
 }
 
 resource "aws_appautoscaling_policy" "autoscaling_read_replica_count" {
-  count = "${var.replica_scale_enabled ? 1 : 0}"
+  count = var.replica_scale_enabled ? 1 : 0
 
   name               = "target-metric"
   policy_type        = "TargetTrackingScaling"
@@ -111,13 +137,13 @@ resource "aws_appautoscaling_policy" "autoscaling_read_replica_count" {
 
   target_tracking_scaling_policy_configuration {
     predefined_metric_specification {
-      predefined_metric_type = "RDSReaderAverageCPUUtilization"
+      predefined_metric_type = var.predefined_metric_type
     }
 
-    scale_in_cooldown  = "${var.replica_scale_in_cooldown}"
-    scale_out_cooldown = "${var.replica_scale_out_cooldown}"
-    target_value       = "${var.replica_scale_cpu}"
+    scale_in_cooldown  = var.replica_scale_in_cooldown
+    scale_out_cooldown = var.replica_scale_out_cooldown
+    target_value       = var.predefined_metric_type == "RDSReaderAverageCPUUtilization" ? var.replica_scale_cpu : var.replica_scale_connections
   }
 
-  depends_on = ["aws_appautoscaling_target.read_replica_count"]
+  depends_on = [aws_appautoscaling_target.read_replica_count]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -45,9 +45,3 @@ output "this_rds_cluster_instance_endpoints" {
   description = "A list of all cluster instance endpoints"
   value       = ["${aws_rds_cluster_instance.this.*.endpoint}"]
 }
-
-// aws_security_group
-output "this_security_group_id" {
-  description = "The security group ID of the cluster"
-  value       = "${aws_security_group.this.id}"
-}

--- a/variables.tf
+++ b/variables.tf
@@ -14,8 +14,7 @@ variable "replica_count" {
 
 variable "vpc_security_groups" {
   description = "A list of Security Group ID's to allow access to."
-  type        = "list"
-  default     = []
+  default     = [""]
 }
 
 variable "vpc_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,7 @@ variable "replica_count" {
 
 variable "vpc_security_groups" {
   description = "A list of Security Group ID's to allow access to."
-  default     = [""]
+  default     = ""
 }
 
 variable "vpc_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -12,14 +12,9 @@ variable "replica_count" {
   default     = 1
 }
 
-variable "allowed_security_groups" {
+variable "vpc_security_groups" {
   description = "A list of Security Group ID's to allow access to."
   default     = []
-}
-
-variable "allowed_security_groups_count" {
-  description = "The number of Security Groups being added, terraform doesn't let us use length() in a count field"
-  default     = 0
 }
 
 variable "vpc_id" {
@@ -94,6 +89,12 @@ variable "monitoring_interval" {
   description = "The interval (seconds) between points when Enhanced Monitoring metrics are collected"
   default     = 0
 }
+
+variable "iam_role_enhanced_monitoring_arn" {
+  description = "Enhanched monitoring IAM role ARN"
+  default = ""
+}
+
 
 variable "auto_minor_version_upgrade" {
   description = "Determines whether minor engine upgrades will be performed automatically in the maintenance window"

--- a/variables.tf
+++ b/variables.tf
@@ -206,5 +206,5 @@ variable "engine_mode" {
 
 variable "timeouts" {
   description = "Sets timeout for create/update/delete of cluster and instances"
-  default     = "120"
+  default     = "120m"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,8 @@ variable "replica_count" {
 
 variable "vpc_security_groups" {
   description = "A list of Security Group ID's to allow access to."
-  default     = ""
+  default     = []
+  type        = "list"
 }
 
 variable "vpc_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,18 @@
+variable "create_security_group" {
+  description = "Whether to create security group for RDS cluster"
+  type        = bool
+  default     = true
+}
+
 variable "name" {
   description = "Name given resources"
+  type        = string
 }
 
 variable "subnets" {
   description = "List of subnet IDs to use"
-  type        = "list"
+  type        = list(string)
+  default     = []
 }
 
 variable "replica_count" {
@@ -14,80 +22,95 @@ variable "replica_count" {
 
 variable "vpc_security_groups" {
   description = "A list of Security Group ID's to allow access to."
+  type        = list(string)
   default     = []
-  type        = "list"
 }
 
 variable "vpc_id" {
   description = "VPC ID"
+  type        = string
 }
 
 variable "instance_type" {
   description = "Instance type to use"
+  type        = string
 }
 
 variable "publicly_accessible" {
   description = "Whether the DB should have a public IP address"
-  default     = "false"
+  type        = bool
+  default     = false
 }
 
 variable "database_name" {
   description = "Name for an automatically created database on cluster creation"
+  type        = string
   default     = ""
 }
 
 variable "username" {
   description = "Master DB username"
+  type        = string
   default     = "root"
 }
 
 variable "password" {
   description = "Master DB password"
+  type        = string
   default     = ""
 }
 
 variable "final_snapshot_identifier_prefix" {
   description = "The prefix name to use when creating a final snapshot on cluster destroy, appends a random 8 digits to name to ensure it's unique too."
+  type        = string
   default     = "final"
 }
 
 variable "skip_final_snapshot" {
   description = "Should a final snapshot be created on cluster destroy"
-  default     = "false"
+  type        = bool
+  default     = false
 }
 
 variable "deletion_protection" {
   description = "If the DB instance should have deletion protection enabled"
-  default     = "false"
+  type        = bool
+  default     = false
 }
 
 variable "backup_retention_period" {
   description = "How long to keep backups for (in days)"
-  default     = "7"
+  type        = number
+  default     = 7
 }
 
 variable "preferred_backup_window" {
   description = "When to perform DB backups"
+  type        = string
   default     = "02:00-03:00"
 }
 
 variable "preferred_maintenance_window" {
   description = "When to perform DB maintenance"
+  type        = string
   default     = "sun:05:00-sun:06:00"
 }
 
 variable "port" {
   description = "The port on which to accept connections"
+  type        = string
   default     = ""
 }
 
 variable "apply_immediately" {
   description = "Determines whether or not any DB modifications are applied immediately, or during the maintenance window"
-  default     = "false"
+  type        = bool
+  default     = false
 }
 
 variable "monitoring_interval" {
   description = "The interval (seconds) between points when Enhanced Monitoring metrics are collected"
+  type        = number
   default     = 0
 }
 
@@ -99,118 +122,206 @@ variable "iam_role_enhanced_monitoring_arn" {
 
 variable "auto_minor_version_upgrade" {
   description = "Determines whether minor engine upgrades will be performed automatically in the maintenance window"
-  default     = "true"
+  type        = bool
+  default     = true
 }
 
 variable "db_parameter_group_name" {
   description = "The name of a DB parameter group to use"
-  default     = "default.aurora5.6"
+  type        = string
+  default     = null
 }
 
 variable "db_cluster_parameter_group_name" {
   description = "The name of a DB Cluster parameter group to use"
-  default     = "default.aurora5.6"
+  type        = string
+  default     = null
+}
+
+variable "scaling_configuration" {
+  description = "Map of nested attributes with scaling properties. Only valid when engine_mode is set to `serverless`"
+  type        = map(string)
+  default     = {}
 }
 
 variable "snapshot_identifier" {
   description = "DB snapshot to create this database from"
+  type        = string
   default     = ""
 }
 
 variable "storage_encrypted" {
   description = "Specifies whether the underlying storage layer should be encrypted"
-  default     = "true"
+  type        = bool
+  default     = true
 }
 
 variable "kms_key_id" {
   description = "The ARN for the KMS encryption key if one is set to the cluster."
+  type        = string
   default     = ""
 }
 
 variable "engine" {
   description = "Aurora database engine type, currently aurora, aurora-mysql or aurora-postgresql"
+  type        = string
   default     = "aurora"
 }
 
 variable "engine_version" {
   description = "Aurora database engine version."
+  type        = string
   default     = "5.6.10a"
+}
+
+variable "enable_http_endpoint" {
+  description = "Whether or not to enable the Data API for a serverless Aurora database engine."
+  type        = bool
+  default     = false
 }
 
 variable "replica_scale_enabled" {
   description = "Whether to enable autoscaling for RDS Aurora (MySQL) read replicas"
+  type        = bool
   default     = false
 }
 
 variable "replica_scale_max" {
   description = "Maximum number of replicas to allow scaling for"
-  default     = "0"
+  type        = number
+  default     = 0
 }
 
 variable "replica_scale_min" {
   description = "Minimum number of replicas to allow scaling for"
-  default     = "2"
+  type        = number
+  default     = 2
 }
 
 variable "replica_scale_cpu" {
   description = "CPU usage to trigger autoscaling at"
-  default     = "70"
+  type        = number
+  default     = 70
+}
+
+variable "replica_scale_connections" {
+  description = "Average number of connections to trigger autoscaling at. Default value is 70% of db.r4.large's default max_connections"
+  type        = number
+  default     = 700
 }
 
 variable "replica_scale_in_cooldown" {
   description = "Cooldown in seconds before allowing further scaling operations after a scale in"
-  default     = "300"
+  type        = number
+  default     = 300
 }
 
 variable "replica_scale_out_cooldown" {
   description = "Cooldown in seconds before allowing further scaling operations after a scale out"
-  default     = "300"
+  type        = number
+  default     = 300
 }
 
 variable "tags" {
   description = "A map of tags to add to all resources."
-  type        = "map"
+  type        = map(string)
   default     = {}
 }
 
 variable "performance_insights_enabled" {
   description = "Specifies whether Performance Insights is enabled or not."
+  type        = bool
   default     = false
 }
 
 variable "performance_insights_kms_key_id" {
   description = "The ARN for the KMS key to encrypt Performance Insights data."
+  type        = string
   default     = ""
 }
 
 variable "iam_database_authentication_enabled" {
   description = "Specifies whether IAM Database authentication should be enabled or not. Not all versions and instances are supported. Refer to the AWS documentation to see which versions are supported."
+  type        = bool
   default     = false
 }
 
 variable "enabled_cloudwatch_logs_exports" {
   description = "List of log types to export to cloudwatch"
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
 variable "global_cluster_identifier" {
   description = "The global cluster identifier specified on aws_rds_global_cluster"
+  type        = string
   default     = ""
 }
 
 variable "engine_mode" {
   description = "The database engine mode. Valid values: global, parallelquery, provisioned, serverless."
+  type        = string
   default     = "provisioned"
 }
 
-variable "timeouts" {
-  description = "Sets timeout for create/update/delete of cluster and instances"
-  default     = "120m"
+variable "replication_source_identifier" {
+  description = "ARN of a source DB cluster or DB instance if this DB cluster is to be created as a Read Replica."
+  default     = ""
+}
+
+variable "source_region" {
+  description = "The source region for an encrypted replica DB cluster."
+  default     = ""
+}
+
+variable "vpc_security_group_ids" {
+  description = "List of VPC security groups to associate to the cluster in addition to the SG we create in this module"
+  type        = list(string)
+  default     = []
+}
+
+variable "db_subnet_group_name" {
+  description = "The existing subnet group name to use"
+  type        = string
+  default     = ""
+}
+
+variable "predefined_metric_type" {
+  description = "The metric type to scale on. Valid values are RDSReaderAverageCPUUtilization and RDSReaderAverageDatabaseConnections."
+  default     = "RDSReaderAverageCPUUtilization"
+}
+
+variable "backtrack_window" {
+  description = "The target backtrack window, in seconds. Only available for aurora engine currently. To disable backtracking, set this value to 0. Defaults to 0. Must be between 0 and 259200 (72 hours)"
+  type        = number
+  default     = 0
+}
+
+variable "copy_tags_to_snapshot" {
+  description = "Copy all Cluster tags to snapshots."
+  type        = bool
+  default     = false
+}
+
+variable "iam_roles" {
+  description = "A List of ARNs for the IAM roles to associate to the RDS Cluster."
+  type        = list(string)
+  default     = []
+}
+
+variable "security_group_description" {
+  description = "The description of the security group. If value is set to empty string it will contain cluster name in the description."
+  type        = string
+  default     = "Managed by Terraform"
 }
 
 variable "ca_cert_identifier" {
   description = "The identifier of the CA certificate for the DB instance"
   type        = string
   default     = "rds-ca-2019"
+}
+
+variable "timeouts" {
+  description = "Sets timeout for create/update/delete of cluster and instances"
+  default     = "120m"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,11 +7,6 @@ variable "subnets" {
   type        = "list"
 }
 
-variable "identifier_prefix" {
-  description = "Prefix for cluster and instance identifier"
-  default     = ""
-}
-
 variable "replica_count" {
   description = "Number of reader nodes to create.  If `replica_scale_enable` is `true`, the value of `replica_scale_min` is used instead."
   default     = 1

--- a/variables.tf
+++ b/variables.tf
@@ -208,3 +208,9 @@ variable "timeouts" {
   description = "Sets timeout for create/update/delete of cluster and instances"
   default     = "120m"
 }
+
+variable "ca_cert_identifier" {
+  description = "The identifier of the CA certificate for the DB instance"
+  type        = string
+  default     = "rds-ca-2019"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -203,3 +203,8 @@ variable "engine_mode" {
   description = "The database engine mode. Valid values: global, parallelquery, provisioned, serverless."
   default     = "provisioned"
 }
+
+variable "timeouts" {
+  description = "Sets timeout for create/update/delete of cluster and instances"
+  default     = "120"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,7 @@ variable "replica_count" {
 
 variable "vpc_security_groups" {
   description = "A list of Security Group ID's to allow access to."
+  type        = "list"
   default     = []
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = "~> 0.12.6"
+
+  required_providers {
+    aws    = "~> 2.45"
+    random = "~> 2.2"
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.60"
+      version = "~> 3.30" # Allows for modules that use the TF SG module that need <3.38.
     }
   }
   required_version = ">= 0.14"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">= 0.12"
 
   required_providers {
     aws    = "~> 2.45"

--- a/versions.tf
+++ b/versions.tf
@@ -1,8 +1,9 @@
 terraform {
-  required_version = ">= 0.12"
-
   required_providers {
-    aws    = "~> 2.45"
-    random = "~> 2.2"
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.60"
+    }
   }
+  required_version = ">= 0.14"
 }


### PR DESCRIPTION
Allow wider AWS versions for modules that use the TF SG module. It requires < 3.38 of the AWS provider at this time. 