### PR TITLE
fix: Allow available custom vpc id in cluster

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,7 @@ resource "aws_rds_cluster" "this" {
   preferred_maintenance_window        = local.is_serverless ? null : var.preferred_maintenance_window
   port                                = local.port
   db_subnet_group_name                = local.db_subnet_group_name
+  vpc_id                              = var.vpc_id
   vpc_security_group_ids              = compact(concat(aws_security_group.this.*.id, var.vpc_security_group_ids))
   snapshot_identifier                 = var.snapshot_identifier
   storage_encrypted                   = var.storage_encrypted


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
the RDS cluster use only default vpc.
Need to add vpc id in rds cluster

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#310 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
