### PR TITLE
feat: Add support to create a headless cluster

### DIFF
--- a/examples/global-cluster/README.md
+++ b/examples/global-cluster/README.md
@@ -50,7 +50,9 @@ Note that this example may create resources which cost money. Run `terraform des
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_create_secondary_headless_cluster"></a> [create\_secondary\_headless\_cluster](#input\_create\_secondary\_headless\_cluster) | Creates the secondary cluster as headless | `bool` | `false` | no |
 
 ## Outputs
 

--- a/examples/global-cluster/main.tf
+++ b/examples/global-cluster/main.tf
@@ -68,7 +68,8 @@ module "aurora_secondary" {
 
   providers = { aws = aws.secondary }
 
-  is_primary_cluster = false
+  is_primary_cluster  = false
+  is_headless_cluster = var.create_secondary_headless_cluster
 
   name                      = local.name
   engine                    = aws_rds_global_cluster.this.engine

--- a/examples/global-cluster/variables.tf
+++ b/examples/global-cluster/variables.tf
@@ -1,0 +1,5 @@
+variable "create_secondary_headless_cluster" {
+  description = "Creates the secondary cluster as headless"
+  type        = bool
+  default     = false
+}

--- a/main.tf
+++ b/main.tf
@@ -169,7 +169,7 @@ resource "aws_rds_cluster" "this" {
 ################################################################################
 
 resource "aws_rds_cluster_instance" "this" {
-  for_each = { for k, v in var.instances : k => v if local.create_cluster && !local.is_serverless }
+  for_each = { for k, v in var.instances : k => v if local.create_cluster && !local.is_serverless && !var.is_headless_cluster }
 
   apply_immediately                     = try(each.value.apply_immediately, var.apply_immediately)
   auto_minor_version_upgrade            = try(each.value.auto_minor_version_upgrade, var.auto_minor_version_upgrade)

--- a/variables.tf
+++ b/variables.tf
@@ -70,6 +70,12 @@ variable "is_primary_cluster" {
   default     = true
 }
 
+variable "is_headless_cluster" {
+  description = "Determines whether cluster is headless (tipically set to `true` for replica clusters, a headless secondary Aurora DB cluster is one without a DB instance, check https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database-getting-started.html#aurora-global-database-attach.console.headless for more info)"
+  type        = bool
+  default     = false
+}
+
 variable "cluster_use_name_prefix" {
   description = "Whether to use `name` as a prefix for the cluster"
   type        = bool


### PR DESCRIPTION
## Description
Allows to create a headless Aurora DB cluster, like explained in the docs:
- https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database-getting-started.html#aurora-global-database-attach.console.headless
- https://aws.amazon.com/blogs/database/achieve-cost-effective-multi-region-resiliency-with-amazon-aurora-global-database-headless-clusters/

## Motivation and Context
Achieve cost-effective multi-Region resiliency with Amazon Aurora Global Database headless clusters.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
No.
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [X] I have used this module to provision an Aurora Global Database with clusters in two regions, being the secondary a headless cluster
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
