### PR TITLE
docs: Correct typo in `UPGRADE-6.0.md`

### DIFF
--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -165,7 +165,7 @@ module "cluster_after" {
       instance_class          = "db.r5.large"
       instance_promotion_tier = 15
     }
-  ]
+  }
 
   + autoscaling_enabled      = true
   + autoscaling_min_capacity = 1


### PR DESCRIPTION
I believe that this should be` } `and not `]`

## Description
<!--- Describe your changes in detail -->
Read that while tryng to follow the docs of the migration to v6.
