### PR TITLE
aws_db_parameter_group: set lifecycle.create_before_destroy = true

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -424,5 +424,10 @@ resource "aws_db_parameter_group" "this" {
     }
   }
 
+  # https://github.com/hashicorp/terraform-provider-aws/issues/6448#issuecomment-848389991
+  lifecycle {
+    create_before_destroy = true
+  }
+
   tags = var.tags
 }


### PR DESCRIPTION
## Description
This allows changing the engine version, without failing with the following error message:

 Error: Error deleting DB parameter group: InvalidDBParameterGroupState: One or more database instances are still members of this parameter group foo-postgres12-parameter-group, so the group cannot be deleted
	status code: 400, request id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx


## Motivation and Context
I previously used `db_cluster_parameter_group_name` and `db_parameter_group_name` to point to some externally-created parameter group names.

While trying to update the `engine_version`, it failed with some incompatibilities, so I wanted to switch to having the terraform module create them.

I:

 - removed `db_cluster_parameter_group_name`
 - removed `db_parameter_group_name`
 - added `create_db_cluster_parameter_group = true`
 - added `create_db_parameter_group = true`
 - added `db_cluster_parameter_group_family = "aurora-postgresql12"
 - added `db_parameter_group_family = "aurora-postgresql12"`

I moved the pre-existing parameter groups into the module state:

```
tf state mv 'module.foo.aws_db_parameter_group.aurora_db_postgres12_parameter_group' 'module.foo.module.aurora.aws_db_parameter_group.this[0]'
tf state mv 'module.foo.aws_rds_cluster_parameter_group.aurora_cluster_postgres12_parameter_group' 'module.foo.module.aurora.aws_rds_cluster_parameter_group.this[0]'
```

Terraform tried to delete the parameter groups first, before creating the new ones:


>  Error: Error deleting DB parameter group: InvalidDBParameterGroupState: One or more database instances are still members of this parameter group foo-postgres12-parameter-group, so the group cannot be deleted
	status code: 400, request id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx

Setting `lifecycle.before_destroy` on the `lifecycle.create_before_destroy = true` on the `aws_db_parameter_group` seems to help. Terraform first creates the new DB parameter group, and then removes the old one.

This has also been suggested in https://github.com/hashicorp/terraform-provider-aws/issues/6448#issuecomment-848389991.


## Breaking Changes
N/A

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
