### PR TITLE
default value for engine_mode

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -175,7 +175,7 @@ variable "engine" {
 variable "engine_mode" {
   description = "The database engine mode. Valid values: `global`, `multimaster`, `parallelquery`, `provisioned`, `serverless`. Defaults to: `provisioned`"
   type        = string
-  default     = null
+  default     = "provisioned"
 }
 
 variable "engine_version" {


### PR DESCRIPTION
sets default value for `engine_mode` var as is in the description

## Description
sets default value for `engine_mode`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
without this, if engine_mode is not specified, `serverlessv2_scaling_configuration` will not take effect since it expects an actual value of `provisioned` in `engine_mode` 

## Breaking Changes
None
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
