### PR TITLE
fix: Use `create_before_destroy` lifecycle on parameter groups to support major version upgrades

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -399,6 +399,10 @@ resource "aws_rds_cluster_parameter_group" "this" {
     }
   }
 
+  lifecycle {
+    create_before_destroy = true
+  }
+
   tags = var.tags
 }
 
@@ -422,6 +426,10 @@ resource "aws_db_parameter_group" "this" {
       value        = parameter.value.value
       apply_method = try(parameter.value.apply_method, "immediate")
     }
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 
   tags = var.tags


### PR DESCRIPTION
## Description
Use the create_before_destroy lifecycle setting for the parameter groups so that major version updates are possible.

## Motivation and Context
It enables major version upgrades.
It fixes: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/353

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
