### PR TITLE
feat: Allow override of protocol in egress rule

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -368,7 +368,7 @@ resource "aws_security_group_rule" "egress" {
   type              = "egress"
   from_port         = try(each.value.from_port, local.port)
   to_port           = try(each.value.to_port, local.port)
-  protocol          = "tcp"
+  protocol          = try(each.value.protocol, "tcp")
   security_group_id = aws_security_group.this[0].id
 
   # optional


### PR DESCRIPTION
## Description
Allow override of protocol in egress rule.

## Motivation and Context
TCP are insufficient in case of S3 export.

## Breaking Changes
No.

## How Has This Been Tested?
By creating new SG with `protocol` set to `all`.
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
