### PR TITLE
Add dependency for aws_rds_cluster_instance

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -204,6 +204,10 @@ resource "aws_rds_cluster_instance" "this" {
     update = try(var.instance_timeouts.update, null)
     delete = try(var.instance_timeouts.delete, null)
   }
+
+  depends_on = [
+    aws_rds_cluster.this
+  ]
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
Add dependency for `aws_rds_cluster_instance` on `aws_rds_cluster`.

## Motivation and Context
Prevent InvalidDBClusterStateFault.

## Breaking Changes
N/A

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request