### PR TITLE
fix: Allow setting `master_username` when using `manage_master_user_password`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.1
+    rev: v1.77.2
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,7 @@ resource "aws_rds_cluster" "this" {
   manage_master_user_password   = var.global_cluster_identifier == null && var.manage_master_user_password ? var.manage_master_user_password : null
   master_user_secret_kms_key_id = var.global_cluster_identifier == null && var.manage_master_user_password ? var.master_user_secret_kms_key_id : null
   master_password               = var.is_primary_cluster && !var.manage_master_user_password ? var.master_password : null
-  master_username               = var.is_primary_cluster && !var.manage_master_user_password ? var.master_username : null
+  master_username               = var.is_primary_cluster ? var.master_username : null
   network_type                  = var.network_type
   port                          = local.port
   preferred_backup_window       = local.is_serverless ? null : var.preferred_backup_window


### PR DESCRIPTION
## Description
- Allow setting `master_username` when using `manage_master_user_password`

## Motivation and Context
- Resolves #368

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
