### PR TITLE
feat: Ability to set custom `security_group_name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ No modules.
 | <a name="input_s3_import"></a> [s3\_import](#input\_s3\_import) | Configuration map used to restore from a Percona Xtrabackup in S3 (only MySQL is supported) | `map(string)` | `{}` | no |
 | <a name="input_scaling_configuration"></a> [scaling\_configuration](#input\_scaling\_configuration) | Map of nested attributes with scaling properties. Only valid when `engine_mode` is set to `serverless` | `map(string)` | `{}` | no |
 | <a name="input_security_group_description"></a> [security\_group\_description](#input\_security\_group\_description) | The description of the security group. If value is set to empty string it will contain cluster name in the description | `string` | `null` | no |
+| <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | The security group name. Default value is (`var.name`) | `string` | `""` | no |
 | <a name="input_security_group_rules"></a> [security\_group\_rules](#input\_security\_group\_rules) | Map of security group rules to add to the cluster security group created | `any` | `{}` | no |
 | <a name="input_security_group_tags"></a> [security\_group\_tags](#input\_security\_group\_tags) | Additional tags for the security group | `map(string)` | `{}` | no |
 | <a name="input_security_group_use_name_prefix"></a> [security\_group\_use\_name\_prefix](#input\_security\_group\_use\_name\_prefix) | Determines whether the security group name (`var.name`) is used as a prefix | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,8 @@ locals {
   internal_db_subnet_group_name = try(coalesce(var.db_subnet_group_name, var.name), "")
   db_subnet_group_name          = var.create_db_subnet_group ? try(aws_db_subnet_group.this[0].name, null) : local.internal_db_subnet_group_name
 
+  security_group_name = try(coalesce(var.security_group_name, var.name), "")
+
   cluster_parameter_group_name = try(coalesce(var.db_cluster_parameter_group_name, var.name), null)
   db_parameter_group_name      = try(coalesce(var.db_parameter_group_name, var.name), null)
 
@@ -306,8 +308,8 @@ resource "aws_appautoscaling_policy" "this" {
 resource "aws_security_group" "this" {
   count = local.create && var.create_security_group ? 1 : 0
 
-  name        = var.security_group_use_name_prefix ? null : var.name
-  name_prefix = var.security_group_use_name_prefix ? "${var.name}-" : null
+  name        = var.security_group_use_name_prefix ? null : local.security_group_name
+  name_prefix = var.security_group_use_name_prefix ? "${local.security_group_name}-" : null
   vpc_id      = var.vpc_id
   description = coalesce(var.security_group_description, "Control traffic to/from RDS Aurora ${var.name}")
 

--- a/variables.tf
+++ b/variables.tf
@@ -546,6 +546,12 @@ variable "create_security_group" {
   default     = true
 }
 
+variable "security_group_name" {
+  description = "The security group name. Default value is (`var.name`)"
+  type        = string
+  default     = ""
+}
+
 variable "security_group_use_name_prefix" {
   description = "Determines whether the security group name (`var.name`) is used as a prefix"
   type        = bool


### PR DESCRIPTION
## Description

I have a scenario where I would like the security group name to be different. The RDS is called after the service, e.g. `myapp-staging`. I would like the security group to be named `myapp-staging-rds`. This change will allow to customise the security group name while keeping backwards compatiblity.

fixes #376

## Motivation and Context

I have multiple security groups, each with a prefix:

* `myapp-staging-default`
* `myapp-staging-rds-proxy`
* `myapp-staging-lambda-app`
* ...

The only security group not matching this schema is created by the `terraform-aws-rds-aurora` module.

## Breaking Changes

None.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
