### PR TITLE
fix: Tag security group with correct name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -313,7 +313,7 @@ resource "aws_security_group" "this" {
   vpc_id      = var.vpc_id
   description = coalesce(var.security_group_description, "Control traffic to/from RDS Aurora ${var.name}")
 
-  tags = merge(var.tags, var.security_group_tags, { Name = var.name })
+  tags = merge(var.tags, var.security_group_tags, { Name = local.security_group_name })
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
## Description

The introduction of `security_group_name` (#376) missed the adjustment of the `Name` tag for the security group. This rectifies this issue.

## Motivation and Context

Consistency and correctness.

## Breaking Changes

None.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
