### PR TITLE
feat: Upgrade aws provider version and update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,13 +224,13 @@ Terraform documentation is generated automatically using [pre-commit hooks](http
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.61 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.67 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.61 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.67 |
 
 ## Modules
 

--- a/examples/autoscaling/README.md
+++ b/examples/autoscaling/README.md
@@ -20,13 +20,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.61 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.67 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.61 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.67 |
 
 ## Modules
 

--- a/examples/autoscaling/main.tf
+++ b/examples/autoscaling/main.tf
@@ -25,11 +25,12 @@ locals {
 module "aurora" {
   source = "../../"
 
-  name           = local.name
-  engine         = "aurora-postgresql"
-  engine_version = "14.5"
-  instance_class = "db.r6g.large"
-  instances      = { 1 = {} }
+  name            = local.name
+  engine          = "aurora-postgresql"
+  engine_version  = "14.5"
+  instance_class  = "db.r6g.large"
+  instances       = { 1 = {} }
+  master_username = "root"
 
   vpc_id               = module.vpc.vpc_id
   db_subnet_group_name = module.vpc.database_subnet_group_name

--- a/examples/autoscaling/versions.tf
+++ b/examples/autoscaling/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.61"
+      version = "~> 4.67"
     }
   }
 }

--- a/examples/global-cluster/README.md
+++ b/examples/global-cluster/README.md
@@ -20,15 +20,15 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.61 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.67 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.61 |
-| <a name="provider_aws.secondary"></a> [aws.secondary](#provider\_aws.secondary) | ~> 4.61 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.67 |
+| <a name="provider_aws.secondary"></a> [aws.secondary](#provider\_aws.secondary) | ~> 4.67 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.2 |
 
 ## Modules

--- a/examples/global-cluster/main.tf
+++ b/examples/global-cluster/main.tf
@@ -50,6 +50,7 @@ module "aurora_primary" {
   database_name             = aws_rds_global_cluster.this.database_name
   engine                    = aws_rds_global_cluster.this.engine
   engine_version            = aws_rds_global_cluster.this.engine_version
+  master_username           = "root"
   global_cluster_identifier = aws_rds_global_cluster.this.id
   instance_class            = "db.r6g.large"
   instances                 = { for i in range(2) : i => {} }

--- a/examples/global-cluster/main.tf
+++ b/examples/global-cluster/main.tf
@@ -65,7 +65,8 @@ module "aurora_primary" {
   }
 
   # Global clusters do not support managed master user password
-  master_password = random_password.master.result
+  manage_master_user_password = false
+  master_password             = random_password.master.result
 
   skip_final_snapshot = true
 

--- a/examples/global-cluster/versions.tf
+++ b/examples/global-cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.61"
+      version = "~> 4.67"
     }
 
     random = {

--- a/examples/multi-az/README.md
+++ b/examples/multi-az/README.md
@@ -20,13 +20,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.61 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.67 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.61 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.67 |
 
 ## Modules
 

--- a/examples/multi-az/main.tf
+++ b/examples/multi-az/main.tf
@@ -25,9 +25,10 @@ locals {
 module "aurora" {
   source = "../../"
 
-  name           = local.name
-  engine         = "postgres" # This uses RDS engine, not Aurora
-  engine_version = "14.5"
+  name            = local.name
+  engine          = "postgres" # This uses RDS engine, not Aurora
+  engine_version  = "14.5"
+  master_username = "root"
 
   vpc_id               = module.vpc.vpc_id
   db_subnet_group_name = module.vpc.database_subnet_group_name

--- a/examples/multi-az/versions.tf
+++ b/examples/multi-az/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.61"
+      version = "~> 4.67"
     }
   }
 }

--- a/examples/mysql/README.md
+++ b/examples/mysql/README.md
@@ -20,13 +20,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.61 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.67 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.61 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.67 |
 
 ## Modules
 

--- a/examples/mysql/main.tf
+++ b/examples/mysql/main.tf
@@ -25,9 +25,10 @@ locals {
 module "aurora" {
   source = "../../"
 
-  name           = local.name
-  engine         = "aurora-mysql"
-  engine_version = "8.0"
+  name            = local.name
+  engine          = "aurora-mysql"
+  engine_version  = "8.0"
+  master_username = "root"
   instances = {
     1 = {
       instance_class      = "db.r5.large"

--- a/examples/mysql/versions.tf
+++ b/examples/mysql/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.61"
+      version = "~> 4.67"
     }
   }
 }

--- a/examples/postgresql/README.md
+++ b/examples/postgresql/README.md
@@ -20,13 +20,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.61 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.67 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.61 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.67 |
 
 ## Modules
 

--- a/examples/postgresql/main.tf
+++ b/examples/postgresql/main.tf
@@ -25,9 +25,11 @@ locals {
 module "aurora" {
   source = "../../"
 
-  name           = local.name
-  engine         = "aurora-postgresql"
-  engine_version = "14.5"
+  name            = local.name
+  engine          = "aurora-postgresql"
+  engine_version  = "14.7"
+  master_username = "root"
+  storage_type    = "aurora-iopt1"
   instances = {
     1 = {
       instance_class      = "db.r5.2xlarge"

--- a/examples/postgresql/versions.tf
+++ b/examples/postgresql/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.61"
+      version = "~> 4.67"
     }
   }
 }

--- a/examples/s3-import/README.md
+++ b/examples/s3-import/README.md
@@ -49,13 +49,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.61 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.67 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.61 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.67 |
 
 ## Modules
 

--- a/examples/s3-import/main.tf
+++ b/examples/s3-import/main.tf
@@ -25,11 +25,12 @@ locals {
 module "aurora" {
   source = "../../"
 
-  name           = local.name
-  engine         = "aurora-mysql"
-  engine_version = "5.7.12"
-  instance_class = "db.r5.large"
-  instances      = { 1 = {} }
+  name            = local.name
+  engine          = "aurora-mysql"
+  engine_version  = "5.7.12"
+  master_username = "root"
+  instance_class  = "db.r5.large"
+  instances       = { 1 = {} }
 
   vpc_id               = module.vpc.vpc_id
   db_subnet_group_name = module.vpc.database_subnet_group_name

--- a/examples/s3-import/versions.tf
+++ b/examples/s3-import/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.61"
+      version = "~> 4.67"
     }
   }
 }

--- a/examples/serverless/README.md
+++ b/examples/serverless/README.md
@@ -21,12 +21,14 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.67 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.5 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.67 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.5 |
 
 ## Modules
 
@@ -42,6 +44,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Type |
 |------|------|
+| [random_password.master](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_rds_engine_version.postgresql](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/rds_engine_version) | data source |
 

--- a/examples/serverless/README.md
+++ b/examples/serverless/README.md
@@ -20,13 +20,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.30 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.67 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.30 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.67 |
 
 ## Modules
 

--- a/examples/serverless/main.tf
+++ b/examples/serverless/main.tf
@@ -39,7 +39,7 @@ module "aurora_postgresql" {
     }
   }
 
-  # Serverless clusters do not support managed master user password
+  # Serverless v1 clusters do not support managed master user password
   manage_master_user_password = false
   master_password             = random_password.master.result
 
@@ -82,7 +82,7 @@ module "aurora_mysql" {
     }
   }
 
-  # Serverless clusters do not support managed master user password
+  # Serverless v1 clusters do not support managed master user password
   manage_master_user_password = false
   master_password             = random_password.master.result
 

--- a/examples/serverless/main.tf
+++ b/examples/serverless/main.tf
@@ -39,6 +39,10 @@ module "aurora_postgresql" {
     }
   }
 
+  # Serverless clusters do not support managed master user password
+  manage_master_user_password = false
+  master_password             = random_password.master.result
+
   monitoring_interval = 60
 
   apply_immediately   = true
@@ -77,6 +81,10 @@ module "aurora_mysql" {
       cidr_blocks = module.vpc.private_subnets_cidr_blocks
     }
   }
+
+  # Serverless clusters do not support managed master user password
+  manage_master_user_password = false
+  master_password             = random_password.master.result
 
   monitoring_interval = 60
 
@@ -186,6 +194,10 @@ module "aurora_postgresql_v2" {
 ################################################################################
 # Supporting Resources
 ################################################################################
+resource "random_password" "master" {
+  length  = 20
+  special = false
+}
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"

--- a/examples/serverless/main.tf
+++ b/examples/serverless/main.tf
@@ -29,6 +29,7 @@ module "aurora_postgresql" {
   engine            = "aurora-postgresql"
   engine_mode       = "serverless"
   storage_encrypted = true
+  master_username   = "root"
 
   vpc_id               = module.vpc.vpc_id
   db_subnet_group_name = module.vpc.database_subnet_group_name
@@ -67,6 +68,7 @@ module "aurora_mysql" {
   engine            = "aurora-mysql"
   engine_mode       = "serverless"
   storage_encrypted = true
+  master_username   = "root"
 
   vpc_id               = module.vpc.vpc_id
   db_subnet_group_name = module.vpc.database_subnet_group_name
@@ -106,6 +108,7 @@ module "aurora_mysql_v2" {
   engine_mode       = "provisioned"
   engine_version    = "8.0"
   storage_encrypted = true
+  master_username   = "root"
 
   vpc_id               = module.vpc.vpc_id
   db_subnet_group_name = module.vpc.database_subnet_group_name
@@ -151,6 +154,7 @@ module "aurora_postgresql_v2" {
   engine_mode       = "provisioned"
   engine_version    = data.aws_rds_engine_version.postgresql.version
   storage_encrypted = true
+  master_username   = "root"
 
   vpc_id               = module.vpc.vpc_id
   db_subnet_group_name = module.vpc.database_subnet_group_name

--- a/examples/serverless/versions.tf
+++ b/examples/serverless/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.30"
+      version = ">= 4.67"
     }
   }
 }

--- a/examples/serverless/versions.tf
+++ b/examples/serverless/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.67"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.61"
+      version = "~> 4.67"
     }
   }
 }


### PR DESCRIPTION
## Description
- upgrade aws provider version to address https://github.com/hashicorp/terraform-provider-aws/pull/31336
- add example for aurora I/O optimized - https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/381
- update example with `master_username` since [default is now null](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/blob/89b540474f4e20b2029989e3558eedfaeedb47b3/variables.tf#LL216C1-L216C1) but it's still required if `is_primary` is `true`
- update example for serverless to address `InvalidParameterValue: The parameter ManageMasterUserPassword is not valid for engine mode: serverless.`

## Motivation and Context
- https://github.com/hashicorp/terraform-provider-aws/pull/31336
- Resolves #381
- fixes example errors `InvalidParameterValue: The parameter MasterUsername must be provided and must not be blank.` and `InvalidParameterValue: The parameter ManageMasterUserPassword is not valid for engine mode: serverless.`

## Breaking Changes
None.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
