### PR TITLE
docs: Update storage_type docs entry to mention I/O Optimized storage configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ No modules.
 | <a name="input_snapshot_identifier"></a> [snapshot\_identifier](#input\_snapshot\_identifier) | Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot | `string` | `null` | no |
 | <a name="input_source_region"></a> [source\_region](#input\_source\_region) | The source region for an encrypted replica DB cluster | `string` | `null` | no |
 | <a name="input_storage_encrypted"></a> [storage\_encrypted](#input\_storage\_encrypted) | Specifies whether the DB cluster is encrypted. The default is `true` | `bool` | `true` | no |
-| <a name="input_storage_type"></a> [storage\_type](#input\_storage\_type) | Specifies the storage type to be associated with the DB cluster. (This setting is required to create a Multi-AZ DB cluster). Valid values: `io1`, Default: `io1` | `string` | `null` | no |
+| <a name="input_storage_type"></a> [storage\_type](#input\_storage\_type) | Determines the storage type for the DB cluster. Optional for Single-AZ, required for Multi-AZ DB clusters. Valid values for Single-AZ: `aurora`, `""` (default, both refer to Aurora Standard), `aurora-iopt1` (Aurora I/O Optimized). Valid values for Multi-AZ: `io1` (default). | `string` | `null` | no |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | List of subnet IDs used by database subnet group created | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the VPC where to create security group | `string` | `""` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -295,7 +295,7 @@ variable "storage_encrypted" {
 }
 
 variable "storage_type" {
-  description = "Specifies the storage type to be associated with the DB cluster. (This setting is required to create a Multi-AZ DB cluster). Valid values: `io1`, Default: `io1`"
+  description = "Determines the storage type for the DB cluster. Optional for Single-AZ, required for Multi-AZ DB clusters. Valid values for Single-AZ: `aurora`, `\"\"` (default, both refer to Aurora Standard), `aurora-iopt1` (Aurora I/O Optimized). Valid values for Multi-AZ: `io1` (default)."
   type        = string
   default     = null
 }


### PR DESCRIPTION
## Description

This PR updates the documentation for the `storage_type` input variable, as the usage of the [relatively new Aurora I/O Optimized](https://aws.amazon.com/blogs/aws/new-amazon-aurora-i-o-optimized-cluster-configuration-with-up-to-40-cost-savings-for-i-o-intensive-applications/) storage type wasn't covered by the documentation of this module.

## Motivation and context

Came across Aurora I/O Optimized and tried looking for information on how to configure it with this module. [One of the examples](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/blob/7eec8f4db8f94441e12f961c926820ea6fce1bb7/examples/postgresql/main.tf#L32) actually uses the relevant storage type `aurora-iopt1`, but the option was undocumented.

Relevant references:

- [AWS Terraform provider RDS cluster resource: `storage type`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#storage_type)

## How has this been tested?

To make sure the update to the docs is correct, I tried to create PostgreSQL 15.2 clusters using different combinations with the below results:

| Type | Storage option | Result |
| --- | --- | --- |
| Single-AZ | (blank) | ✅ |
| Single-AZ | `aurora` | ✅ |
| Single-AZ | `aurora-iopt1` | ✅ |
| Multi-AZ | (blank) | ✅ |
| Multi-AZ | `io1` | ✅ |
| Single-AZ | `io1` | ❌ |
| Multi-AZ | `aurora` | ❌ |
| Multi-AZ | `aurora-iopt1` | ❌ |
