### PR TITLE
fix: Ignore changes to restore_to_point_in_time

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -143,6 +143,7 @@ resource "aws_rds_cluster" "this" {
       # See docs here https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_global_cluster#new-global-cluster-from-existing-db-cluster
       global_cluster_identifier,
       snapshot_identifier,
+      restore_to_point_in_time,
     ]
   }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail --> 
Currently removing the field `restore_to_point_in_time` results in a destroy.  This should be ignored so that destroying the source database does not automatically destroy the clone.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Addresses #399

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
This does not break backwards compatibility.  It is in line with other ignore_changes fields such as snapshot_identifier.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
I have a cloned cluster from which I removed `restore_to_point_in_time`.  I added the `restore_to_point_in_time` field to ignore_changes in my local module and confirmed that a plan did not try to destroy the clone.
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
