### PR TITLE
feat: Optionally set db_parameter_group_name for specific rds_cluster_instance

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -162,7 +162,7 @@ resource "aws_rds_cluster_instance" "this" {
   ca_cert_identifier                    = var.ca_cert_identifier
   cluster_identifier                    = aws_rds_cluster.this[0].id
   copy_tags_to_snapshot                 = try(each.value.copy_tags_to_snapshot, var.copy_tags_to_snapshot)
-  db_parameter_group_name               = coalesce(each.value.db_parameter_group_name, var.create_db_parameter_group ? aws_db_parameter_group.this[0].id : var.db_parameter_group_name)
+  db_parameter_group_name               = coalesce(try(each.value.db_parameter_group_name, null), var.create_db_parameter_group ? aws_db_parameter_group.this[0].id : var.db_parameter_group_name)
   db_subnet_group_name                  = local.db_subnet_group_name
   engine                                = var.engine
   engine_version                        = var.engine_version

--- a/main.tf
+++ b/main.tf
@@ -162,7 +162,7 @@ resource "aws_rds_cluster_instance" "this" {
   ca_cert_identifier                    = var.ca_cert_identifier
   cluster_identifier                    = aws_rds_cluster.this[0].id
   copy_tags_to_snapshot                 = try(each.value.copy_tags_to_snapshot, var.copy_tags_to_snapshot)
-  db_parameter_group_name               = var.create_db_parameter_group ? aws_db_parameter_group.this[0].id : var.db_parameter_group_name
+  db_parameter_group_name               = coalesce(each.value.db_parameter_group_name, var.create_db_parameter_group ? aws_db_parameter_group.this[0].id : var.db_parameter_group_name)
   db_subnet_group_name                  = local.db_subnet_group_name
   engine                                = var.engine
   engine_version                        = var.engine_version


### PR DESCRIPTION
## Description

Add capability to set `db_parameter_group_name` for a specific database cluster instance

## Motivation and Context

Suppose I want to set a DB that has longer query timeout from other instances in the cluster (e.g. for analytics purposes). I want to create a custom endpoint that only has this DB instance with a different parameter group from the rest. Currently, there is no means of doing this; the `db_parameter_group_name` sets the same parameter group for all instances.

## Breaking Changes

None.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
