### PR TITLE
feat: Enable db_parameter_group_name per instance

### DIFF
--- a/examples/postgresql/main.tf
+++ b/examples/postgresql/main.tf
@@ -32,8 +32,9 @@ module "aurora" {
   storage_type    = "aurora-iopt1"
   instances = {
     1 = {
-      instance_class      = "db.r5.2xlarge"
-      publicly_accessible = true
+      instance_class          = "db.r5.2xlarge"
+      publicly_accessible     = true
+      db_parameter_group_name = "default.aurora-postgresql14"
     }
     2 = {
       identifier     = "static-member-1"

--- a/main.tf
+++ b/main.tf
@@ -162,7 +162,7 @@ resource "aws_rds_cluster_instance" "this" {
   ca_cert_identifier                    = var.ca_cert_identifier
   cluster_identifier                    = aws_rds_cluster.this[0].id
   copy_tags_to_snapshot                 = try(each.value.copy_tags_to_snapshot, var.copy_tags_to_snapshot)
-  db_parameter_group_name               = var.create_db_parameter_group ? aws_db_parameter_group.this[0].id : var.db_parameter_group_name
+  db_parameter_group_name               = var.create_db_parameter_group ? aws_db_parameter_group.this[0].id : try(each.value.db_parameter_group_name, var.db_parameter_group_name)
   db_subnet_group_name                  = local.db_subnet_group_name
   engine                                = var.engine
   engine_version                        = var.engine_version


### PR DESCRIPTION
## Description
Enable to set `db_parameter_group_name` attribute per replica.

## Motivation and Context
Now, we can set `db_parameter_group_name` just in the whole cluster level. We need the ability to set it per instance.
## Breaking Changes
No breaking changes.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
