### PR TITLE
fix: Fix error "The scalable target that you tried to tag already exists"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -276,8 +276,6 @@ resource "aws_appautoscaling_target" "this" {
   resource_id        = "cluster:${aws_rds_cluster.this[0].cluster_identifier}"
   scalable_dimension = "rds:cluster:ReadReplicaCount"
   service_namespace  = "rds"
-
-  tags = var.tags
 }
 
 resource "aws_appautoscaling_policy" "this" {


### PR DESCRIPTION
ValidationException: The scalable target that you tried to tag already exists. To update tags on an existing scalable target, use the TagResource API.

## Description
<!--- Describe your changes in detail -->

This fix resolves the issue with the error "ValidationException: The scalable target that you tried to tag already exists. To update tags on an existing scalable target, use the TagResource API."

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
