### PR TITLE
fix: Allow Serverless maintenance windows

### DIFF
--- a/examples/serverless/main.tf
+++ b/examples/serverless/main.tf
@@ -8,8 +8,9 @@ locals {
   name   = "ex-${basename(path.cwd)}"
   region = "eu-west-1"
 
-  vpc_cidr = "10.0.0.0/16"
-  azs      = slice(data.aws_availability_zones.available.names, 0, 3)
+  vpc_cidr                     = "10.0.0.0/16"
+  azs                          = slice(data.aws_availability_zones.available.names, 0, 3)
+  preferred_maintenance_window = "sun:05:00-sun:06:00"
 
   tags = {
     Example    = local.name
@@ -45,8 +46,8 @@ module "aurora_postgresql" {
 
   monitoring_interval = 60
 
-  apply_immediately   = true
-  skip_final_snapshot = true
+  preferred_maintenance_window = local.preferred_maintenance_window
+  skip_final_snapshot          = true
 
   # enabled_cloudwatch_logs_exports = # NOT SUPPORTED
 

--- a/main.tf
+++ b/main.tf
@@ -75,7 +75,7 @@ resource "aws_rds_cluster" "this" {
   network_type                  = var.network_type
   port                          = local.port
   preferred_backup_window       = local.is_serverless ? null : var.preferred_backup_window
-  preferred_maintenance_window  = local.is_serverless ? null : var.preferred_maintenance_window
+  preferred_maintenance_window  = var.preferred_maintenance_window
   replication_source_identifier = var.replication_source_identifier
 
   dynamic "restore_to_point_in_time" {


### PR DESCRIPTION
## Description
AWS added support for configuring maintenance windows on Serverless V1 clusters in February 2023, as described in [this announcement](https://aws.amazon.com/about-aws/whats-new/2023/02/amazon-aurora-serverless-v1-configurable-maintenance-windows/). The terraform-aws-rds-aurora module does not pass the preferred_maintenance_window argument down to the aws_rds_cluster resource if engine_mode is serverless.

This change was done in the context of this issue [213](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/pull/213)

Note:
Also tested to set the `preferred_backup_window` attribute on serverless, but it still gives the error:
`InvalidParameterCombination: You currently can't modify BackupWindow with Aurora Serverless`

## Motivation and Context
We cannot warn our customers of database maintenance that has downtime because of this limitation.
- Resolves #395 

## Breaking Changes
There are no breaking changes.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes against several internal existing implementations.
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
