### PR TITLE
fix: Ignore `tags_all` for `aws_appautoscaling_target`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.83.6
+    rev: v1.86.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -27,3 +27,4 @@ repos:
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -531,7 +531,7 @@ All notable changes to this project will be documented in this file
 - Add cluster ARN output as 'this_rds_cluster_arn' ([#48](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/48))
 - Upgraded module to support Terraform 0.12 ([#45](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/45))
 
-### 
+###
 
 on ../../modules/aws-rds-aurora/main.tf line 4, in locals:
 
@@ -579,7 +579,7 @@ when calling import with this module in the configuration.
 - Add cluster ARN output as 'this_rds_cluster_arn' ([#48](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/48))
 - Upgraded module to support Terraform 0.12 ([#45](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/45))
 
-### 
+###
 
 on ../../modules/aws-rds-aurora/main.tf line 4, in locals:
 

--- a/main.tf
+++ b/main.tf
@@ -277,7 +277,13 @@ resource "aws_appautoscaling_target" "this" {
   scalable_dimension = "rds:cluster:ReadReplicaCount"
   service_namespace  = "rds"
 
-  tags = var.enable_appautoscaling_tags ? var.tags : null
+  tags = var.tags
+  
+  lifecycle {
+    ignore_changes = [
+      tags_all,
+    ]
+  }
 }
 
 resource "aws_appautoscaling_policy" "this" {

--- a/main.tf
+++ b/main.tf
@@ -278,7 +278,7 @@ resource "aws_appautoscaling_target" "this" {
   service_namespace  = "rds"
 
   tags = var.tags
-  
+
   lifecycle {
     ignore_changes = [
       tags_all,

--- a/main.tf
+++ b/main.tf
@@ -277,7 +277,7 @@ resource "aws_appautoscaling_target" "this" {
   scalable_dimension = "rds:cluster:ReadReplicaCount"
   service_namespace  = "rds"
 
-  tags = var.tags
+  tags = var.enable_appautoscaling_tags ? var.tags : null
 }
 
 resource "aws_appautoscaling_policy" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -717,9 +717,3 @@ variable "engine_native_audit_fields_included" {
   type        = bool
   default     = false
 }
-
-variable "enable_appautoscaling_tags" {
-  type        = bool
-  default     = true
-  description = "Allow disabling tags on the aws_appautoscaling_target resource. Tags cannot be used on clusters created before 2023-03-30 and causes a perpetual drift."
-}

--- a/variables.tf
+++ b/variables.tf
@@ -717,3 +717,9 @@ variable "engine_native_audit_fields_included" {
   type        = bool
   default     = false
 }
+
+variable "enable_appautoscaling_tags" {
+  type        = bool
+  default     = true
+  description = "Allow disabling tags on the aws_appautoscaling_target resource. Tags cannot be used on clusters created before 2023-03-30 and causes a perpetual drift."
+}


### PR DESCRIPTION
## Description
see https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/430

## Motivation and Context
Fixes perpetual drift in `aws_appautoscaling_target` on clusters created before 2023-03-30, see [docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target)
- Resolves #430 

## Breaking Changes
None

## How Has This Been Tested?
- [x] Tested locally on a cluster created before and after the breaking change in the AWS provider.
