### PR TITLE
enabled KMS key rotation for the code present inside /examples folder tf files - tfsec failure

### DIFF
--- a/examples/global-cluster/main.tf
+++ b/examples/global-cluster/main.tf
@@ -189,6 +189,7 @@ data "aws_iam_policy_document" "rds" {
 
 resource "aws_kms_key" "primary" {
   policy = data.aws_iam_policy_document.rds.json
+  enable_key_rotation = true
   tags   = local.tags
 }
 
@@ -196,5 +197,6 @@ resource "aws_kms_key" "secondary" {
   provider = aws.secondary
 
   policy = data.aws_iam_policy_document.rds.json
+  enable_key_rotation = true
   tags   = local.tags
 }


### PR DESCRIPTION
## Description
enabled KMS key rotation for the code present inside /examples folder tf files - tfsec failure

## Motivation and Context

When we are using this module, we are seeing tfsec failures with error
<testcase classname="**.terraform/modules/rds_provisioned/examples/global-cluster/main.tf**" name="[aws-kms-auto-rotate-keys][MEDIUM] - Key does not have rotation enabled." time="0">
		<failure message="**Key does not have rotation enabled.**" type="">.terraform/modules/rds_provisioned/examples/global-cluster/main.tf:195-200&#xA;&#xA;resource &#34;aws_kms_key&#34; &#34;secondary&#34; {&#xA;  provider = aws.secondary&#xA;&#xA;  policy = data.aws_iam_policy_document.rds.json&#xA;  tags   = local.tags&#xA;}&#xA;&#xA;&#xA;See https://aquasecurity.github.io/tfsec/v1.28.5/checks/aws/kms/auto-rotate-keys/</failure>
	</testcase>

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
