### PR TITLE
fix: Do not create dynamic DNS suffix for service principals

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.0
+    rev: v1.88.4
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/main.tf
+++ b/main.tf
@@ -238,7 +238,7 @@ data "aws_iam_policy_document" "monitoring_rds_assume_role" {
 
     principals {
       type        = "Service"
-      identifiers = ["monitoring.rds.${data.aws_partition.current.dns_suffix}"]
+      identifiers = ["monitoring.rds.amazonaws.com"]
     }
   }
 }


### PR DESCRIPTION
## Description
- Do not create dynamic DNS suffix for service principals

## Motivation and Context
- Resolves #437 

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
