### PR TITLE
docs: Specify type as egress for security group rules in example

### DIFF
--- a/examples/postgresql/main.tf
+++ b/examples/postgresql/main.tf
@@ -69,6 +69,7 @@ module "aurora" {
       cidr_blocks = module.vpc.private_subnets_cidr_blocks
     }
     egress_example = {
+      type        = "egress"
       cidr_blocks = ["10.33.0.0/28"]
       description = "Egress to corporate printer closet"
     }


### PR DESCRIPTION
Specify type as egress for security group rules in postgresql egress example

## Description
<!--- Describe your changes in detail -->
Correct security_group_rules example to specify type = "egress" for egress rules.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
By default the type is ingress, while for egress rule it's required to explicitly specify the type.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
