### PR TITLE
feat: Add tags to aws_appautoscaling_policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -320,12 +320,6 @@ resource "aws_appautoscaling_policy" "this" {
   ]
 
   tags = var.tags
-
-  lifecycle {
-    ignore_changes = [
-      tags_all,
-    ]
-  }
 }
 
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -318,6 +318,14 @@ resource "aws_appautoscaling_policy" "this" {
   depends_on = [
     aws_appautoscaling_target.this
   ]
+
+  tags = var.tags
+
+  lifecycle {
+    ignore_changes = [
+      tags_all,
+    ]
+  }
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
The changes pass the missing tags to `aws_appautoscaling_policy`.

## Motivation and Context
We use this module at work and realised that tags was missing from the resource

## Breaking Changes
None

## How Has This Been Tested?
- should work similar to `aws_appautoscaling_target`
