### PR TITLE
fix: Ignore `tags` for `aws_appautoscaling_target`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -290,9 +290,10 @@ resource "aws_appautoscaling_target" "this" {
   tags = var.tags
 
   lifecycle {
-    ignore_changes = [
+    ignore_changes = var.autoscaling_tags_ignore ? [
+      tags,
       tags_all,
-    ]
+    ] : []
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -590,6 +590,12 @@ variable "autoscaling_target_connections" {
   default     = 700
 }
 
+variable "autoscaling_tags_ignore" {
+  description = "Scalable targets created before 2023-03-20 cannot use tags or default_tags. To prevent terraform plan showing differences that can never be reconciled, set this flag to true"
+  type        = bool
+  default     = false
+}
+
 ################################################################################
 # Security Group
 ################################################################################


### PR DESCRIPTION
## Description  
Scalable targets created before 2023-03-20 may not have an assigned arn. These resource cannot use tags or participate in default_tags. To prevent terraform plan showing differences that can never be reconciled, use the lifecycle.ignore_changes meta-argument Reference: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target


## Motivation and Context
See https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/473

## Breaking Changes
None

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects