### PR TITLE
docs: Update serverless configuration types to be more specifc about available options

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -314,13 +314,24 @@ variable "s3_import" {
 
 variable "scaling_configuration" {
   description = "Map of nested attributes with scaling properties. Only valid when `engine_mode` is set to `serverless`"
-  type        = map(string)
+  type        = object({
+    auto_pause                = optional(bool)
+    min_capacity              = optional(number)
+    max_capacity              = optional(number)
+    seconds_before_timeout    = optional(number)
+    seconds_until_auto_pause  = optional(number)
+    timeout_action            = optional(string)
+  })
   default     = {}
 }
 
 variable "serverlessv2_scaling_configuration" {
   description = "Map of nested attributes with serverless v2 scaling properties. Only valid when `engine_mode` is set to `provisioned`"
-  type        = map(string)
+  type        = object({
+    min_capacity              = optional(number)
+    max_capacity              = optional(number)
+    seconds_until_auto_pause  = optional(number)
+  })
   default     = {}
 }
 


### PR DESCRIPTION
## Description
Updated the variable types on serverless scaling configurations so that you can easily see all the available options.

## Motivation and Context
When working with this module, I had to jump between different documentation pages to find out what is actually available. I think this might make it a bit easier in the future.

## Breaking Changes
I don't think this breaks anything, unless someone is providing values into the config that are not available anyway. And I guess you would get an error in that case anyway.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
