### PR TITLE
fix: Rearranged maps in merge in main.tf:340 for rds aurora security group tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -337,7 +337,7 @@ resource "aws_security_group" "this" {
   vpc_id      = var.vpc_id
   description = coalesce(var.security_group_description, "Control traffic to/from RDS Aurora ${var.name}")
 
-  tags = merge(var.tags, var.security_group_tags, { Name = local.security_group_name })
+  tags = merge(var.tags, { Name = local.security_group_name }, var.security_group_tags)
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
## Description
This change lets the user set a custom name tag for aurora security group in `tags` as it is being overridden by the security group name defined. The change is in the order of the maps in the security group tags.

## Motivation and Context

This change lets module user to set custom name tag for aurora security group instead of the security group name as the value for name tag.
Issue: [#492](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/492)

## Breaking Changes

The current changes renames existing Name tag which does not break any existing infrastructure.


## How Has This Been Tested?

- [ ✅ ] I have tested and validated these changes using one or more of the provided `examples/*` projects

- [ ✅ ] I have executed `pre-commit run -a` on my pull request

