### PR TITLE
feat: Introduce db_cluster_secretsmanager_secret_arn output

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ No modules.
 | <a name="output_db_cluster_cloudwatch_log_groups"></a> [db\_cluster\_cloudwatch\_log\_groups](#output\_db\_cluster\_cloudwatch\_log\_groups) | Map of CloudWatch log groups created and their attributes |
 | <a name="output_db_cluster_parameter_group_arn"></a> [db\_cluster\_parameter\_group\_arn](#output\_db\_cluster\_parameter\_group\_arn) | The ARN of the DB cluster parameter group created |
 | <a name="output_db_cluster_parameter_group_id"></a> [db\_cluster\_parameter\_group\_id](#output\_db\_cluster\_parameter\_group\_id) | The ID of the DB cluster parameter group created |
+| <a name="output_db_cluster_secretsmanager_secret_arn"></a> [db\_cluster\_secretsmanager\_secret\_arn](#output\_db\_cluster\_secretsmanager\_secret\_arn) | Specifies Amazon Resource Name (ARN) of the secret |
 | <a name="output_db_cluster_secretsmanager_secret_rotation_enabled"></a> [db\_cluster\_secretsmanager\_secret\_rotation\_enabled](#output\_db\_cluster\_secretsmanager\_secret\_rotation\_enabled) | Specifies whether automatic rotation is enabled for the secret |
 | <a name="output_db_parameter_group_arn"></a> [db\_parameter\_group\_arn](#output\_db\_parameter\_group\_arn) | The ARN of the DB parameter group created |
 | <a name="output_db_parameter_group_id"></a> [db\_parameter\_group\_id](#output\_db\_parameter\_group\_id) | The ID of the DB parameter group created |

--- a/outputs.tf
+++ b/outputs.tf
@@ -199,6 +199,11 @@ output "db_cluster_secretsmanager_secret_rotation_enabled" {
   value       = try(aws_secretsmanager_secret_rotation.this[0].rotation_enabled, null)
 }
 
+output "db_cluster_secretsmanager_secret_arn" {
+  description = "Specifies Amazon Resource Name (ARN) of the secret"
+  value       = try(aws_secretsmanager_secret_rotation.this[0].secret_id, null)
+}
+
 ################################################################################
 # RDS Shard Group
 ################################################################################


### PR DESCRIPTION
## Description
Change introduces new output `db_cluster_secretsmanager_secret_arn` for current module.

## Motivation and Context
While using `ephemeral` resource like `aws_secretsmanager_secret_version`, you need to specify ARN of the secret to proceed with desired solution for configuring RDS instance. [Example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/ephemeral-resources/secretsmanager_secret_version):
```terraform
ephemeral "aws_secretsmanager_secret_version" "example" {
  secret_id = data.aws_secretsmanager_secret.example.id
}
```
Now, current state of this module isn't provided anything, so you can't simply link ARN of the secret that is created by `manage_master_user_password` and `manage_master_user_password_rotation` fields and proceed with it. So, if module provides this functionality, we can simply use this output `db_cluster_secretsmanager_secret_arn` and use it for configuration needed providers (in my case, `mysql` provider).

## Breaking Changes
No breaking changes, minor bump.
