### PR TITLE
fix: remove unsupported s3Import feature name

### DIFF
--- a/examples/s3-import/main.tf
+++ b/examples/s3-import/main.tf
@@ -40,13 +40,6 @@ module "aurora" {
     }
   }
 
-  iam_roles = {
-    s3_import = {
-      role_arn     = aws_iam_role.s3_import.arn
-      feature_name = ""
-    }
-  }
-
   # S3 import https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Integrating.LoadFromS3.html
   s3_import = {
     source_engine_version = "5.7.12"

--- a/examples/s3-import/main.tf
+++ b/examples/s3-import/main.tf
@@ -43,7 +43,7 @@ module "aurora" {
   iam_roles = {
     s3_import = {
       role_arn     = aws_iam_role.s3_import.arn
-      feature_name = "s3Import"
+      feature_name = ""
     }
   }
 


### PR DESCRIPTION
## Description
As described here https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/273, s3Import is not accepted any more. I have tested with an empty string and it works.