### PR TITLE
feat: Add `create_before_destroy` to Aurora DB instance resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -201,6 +201,11 @@ resource "aws_rds_cluster_instance" "this" {
     update = try(var.instance_timeouts.update, null)
     delete = try(var.instance_timeouts.delete, null)
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
Add a `create_before_destroy` lifecycle block to the `aws_rds_cluster_instance` resources.

## Motivation and Context
This improves time to recover in the (uncommon) case where the DB instances have to be replaced, for example to change their identifier or network configuration. We have observed that it can take nearly 10 minutes to destroy an Aurora instance. And then a similar time to create its replacement. During this time the DB is inaccessible. By using `create_before_destroy`, there is only a small interruption while one of the new instances is promoted to the Writer role. Which seems to typically take less than 30 seconds. 

## Breaking Changes
N/A

## How Has This Been Tested?
- [x] I have tested and validated these changes using an internal fork of this module
- [x] I have executed `pre-commit run -a` on my pull request

There is nothing to change in the `examples`, everything is internal to the code of the module.