### PR TITLE
feat: Ephemeral password support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,6 +78,8 @@ resource "aws_rds_cluster" "this" {
   manage_master_user_password           = var.global_cluster_identifier == null && var.manage_master_user_password ? var.manage_master_user_password : null
   master_user_secret_kms_key_id         = var.global_cluster_identifier == null && var.manage_master_user_password ? var.master_user_secret_kms_key_id : null
   master_password                       = var.is_primary_cluster && !var.manage_master_user_password ? var.master_password : null
+  master_password_wo                    = var.master_password_wo
+  master_password_wo_version            = var.master_password_wo_version
   master_username                       = var.is_primary_cluster ? var.master_username : null
   monitoring_interval                   = var.cluster_monitoring_interval
   monitoring_role_arn                   = var.create_monitoring_role && var.cluster_monitoring_interval > 0 ? try(aws_iam_role.rds_enhanced_monitoring[0].arn, null) : var.monitoring_role_arn

--- a/variables.tf
+++ b/variables.tf
@@ -282,6 +282,20 @@ variable "master_password" {
   default     = null
 }
 
+variable "master_password_wo" {
+  description = "Write-only password for the master DB user. Required unless `manage_master_user_password` is set to `true`, or unless `snapshot_identifier` or `replication_source_identifier` is provided, or unless a `global_cluster_identifier` is provided when the cluster is the secondary cluster of a global database. Unlike `master_password`, this value will not be stored in the Terraform state file"
+  type        = string
+  ephemeral   = true
+  default     = null
+}
+
+variable "master_password_wo_version" {
+  description = "Optional version identifier used to detect changes in `master_password_wo` and force update. Increment to rotate the password."
+  type        = string
+  default     = null
+}
+
+
 variable "master_username" {
   description = "Username for the master DB user. Required unless `snapshot_identifier` or `replication_source_identifier` is provided or unless a `global_cluster_identifier` is provided when the cluster is the secondary cluster of a global database"
   type        = string


### PR DESCRIPTION
## Description
This update adds support for ephemeral master passwords (master_password_wo) in RDS/Aurora clusters.
With this option, the master password is write-only and never stored in the Terraform state.

## Motivation
Since "manage_master_user_password" has annoying behavior with enabled rotation by default, and "master_password" stores the value in state, this solution provides an alternative.

## How Has This Been Tested?
### Tested with a few options:

### Option 1

manage_master_user_password = false
master_password                        = false
master_password_wo                  = true

Result: Deploy successful and connection with "wo" password works

### Option 2

manage_master_user_password = false
master_password                        = true
master_password_wo                  = true

Result: Conflicting configuration arguments (expected)

### Option 3

manage_master_user_password = true
master_password                        = false
master_password_wo                  = true

Result: Conflicting configuration arguments (expected)

## Usage

Generate a password via ephemeral, put result into Secret Manager, and retrieve version of the secret.

```hcl
ephemeral "random_password" "db_password" {
  length           = 16
  override_special = "!#$%&*()-_=+[]{}<>:?"
}

resource "aws_secretsmanager_secret" "db_password" {
  name = "db_password"
}

resource "aws_secretsmanager_secret_version" "db_password" {
  secret_id                = aws_secretsmanager_secret.db_password.id
  secret_string_wo         = ephemeral.random_password.db_password.result
  secret_string_wo_version = 1
}

ephemeral "aws_secretsmanager_secret_version" "db_password" {
  secret_id = aws_secretsmanager_secret_version.db_password.secret_id
}
```

Pass necessary variables into module:

```hcl
manage_master_user_password = false
master_password_wo          = ephemeral.aws_secretsmanager_secret_version.db_password.secret_string
master_password_wo_version  = aws_secretsmanager_secret_version.db_password.secret_string_wo_version

```