### PR TITLE
add cluster tags to module output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -89,6 +89,16 @@ output "cluster_ca_certificate_valid_till" {
   value       = try(aws_rds_cluster.this[0].ca_certificate_valid_till, null)
 }
 
+output "cluster_tags" {
+  description = "The map of tags assigned to the cluster"
+  value       = try(aws_rds_cluster.this[0].tags, null)
+}
+
+output "cluster_tags_all" {
+  description = "The map of tags assigned to the cluster"
+  value       = try(aws_rds_cluster.this[0].tags_all, null)
+}
+
 ################################################################################
 # Cluster Instance(s)
 ################################################################################


### PR DESCRIPTION
## Description
Expose the `tags` and `tags_all` attributes of the `aws_rds_cluster` resource on the module output.

## Motivation and Context
If I need the cluster tags in a dependency, I do not want to (and sometimes cannot) rely on the instance tags.

## Breaking Changes
No.

## How Has This Been Tested?
This is not a huge change. Just run apply, then check the output.