### PR TITLE
fix: Correct iterator name in dynamic timeouts blocks

### DIFF
--- a/examples/serverless/main.tf
+++ b/examples/serverless/main.tf
@@ -118,9 +118,16 @@ module "aurora_postgresql" {
   }
 
   cluster_instance_class = "db.serverless"
+  cluster_timeouts = {
+    delete = "30m"
+  }
+
   instances = {
     one = {}
     two = {}
+  }
+  instance_timeouts = {
+    delete = "30m"
   }
 
   tags = local.tags

--- a/main.tf
+++ b/main.tf
@@ -158,9 +158,9 @@ resource "aws_rds_cluster" "this" {
     for_each = var.cluster_timeouts != null ? [var.cluster_timeouts] : []
 
     content {
-      create = each.value.create
-      update = each.value.update
-      delete = each.value.delete
+      create = timeouts.value.create
+      update = timeouts.value.update
+      delete = timeouts.value.delete
     }
   }
 
@@ -216,9 +216,9 @@ resource "aws_rds_cluster_instance" "this" {
     for_each = var.instance_timeouts != null ? [var.instance_timeouts] : []
 
     content {
-      create = each.value.create
-      update = each.value.update
-      delete = each.value.delete
+      create = timeouts.value.create
+      update = timeouts.value.update
+      delete = timeouts.value.delete
     }
   }
 


### PR DESCRIPTION
## Description
Fixed incorrect iterator reference in dynamic `timeouts` blocks. Changed from `each.value` to `timeouts.value` to match the actual iterator label in both `aws_rds_cluster` and `aws_rds_cluster_instance` resources.

## Motivation and Context
The dynamic blocks for timeouts were using `each.value` instead of `timeouts.value`, which would cause runtime errors when `var.cluster_timeouts` or `var.instance_timeouts` are set. This fix ensures the timeouts configuration works correctly when provided.

## Breaking Changes
No breaking changes. This is a bug fix that corrects the implementation to work as intended.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
