### PR TITLE
fix: Set correct security group description

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -382,7 +382,7 @@ resource "aws_security_group" "this" {
   name        = var.security_group_use_name_prefix ? null : local.security_group_name
   name_prefix = var.security_group_use_name_prefix ? "${local.security_group_name}-" : null
   vpc_id      = var.vpc_id
-  description = coalesce(var.security_group_description, "Control traffic to/from RDS Aurora ${var.name}")
+  description = coalesce(var.security_group_description, "Control traffic to/from RDS Aurora ${local.security_group_name}")
 
   tags = merge(
     var.tags,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This should restore the old security group default description convention.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The managed security group description is incorrectly configured. Currently, it outputs `Control traffic to/from RDS Aurora true`. Changing the description of a security group triggers re-creation.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
