### PR TITLE
chore: Usage example argument `instance_class` to `cluster_instance_class` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ module "cluster" {
   name           = "test-aurora-db-postgres96"
   engine         = "aurora-postgresql"
   engine_version = "17.5"
-  instance_class = "db.r8g.large"
+
+  cluster_instance_class = "db.r8g.large"
   instances = {
     one = {}
     two = {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Fix documentation in basic Usage for v10.

`instance_class` to `cluster_instance_class`

https://registry.terraform.io/modules/terraform-aws-modules/rds-aurora/aws/latest#input_cluster_instance_class

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
