### PR TITLE
Ignore cluster_members changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -172,6 +172,7 @@ resource "aws_rds_cluster" "this" {
       # See docs here https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_global_cluster#new-global-cluster-from-existing-db-cluster
       global_cluster_identifier,
       snapshot_identifier,
+      cluster_members,
     ]
   }
 


### PR DESCRIPTION
When AWS recreating db instances cluster_members drift. We need to ignore it to prevent this drift

## Description
DB recreated every time because of cluster_members changes. 

## Motivation and Context
It fixes this issue: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/450

## Breaking Changes
No breaking changes

## How Has This Been Tested?
Tested on real deployment 
