### PR TITLE
docs: Clarify output description for cluster_database_name

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -48,7 +48,7 @@ output "cluster_engine_version_actual" {
 
 # database_name is not set on `aws_rds_cluster` resource if it was not specified, so can't be used in output
 output "cluster_database_name" {
-  description = "Name for an automatically created database on cluster creation"
+  description = "Name for an automatically created database on cluster creation; `null` if input `database_name` is not provided / `null`"
   value       = var.database_name
 }
 


### PR DESCRIPTION
## Description

Updated description for cluster_database_name output to clarify behavior when input database_name is not provided.

The documentation of this module does not mention that output `cluster_database_name` is `null` unless input `database_name` is provided.


## Motivation and Context

I lost about one hour to debug the fact that output `cluster_database_name` is `null`, even though that the auto-generated database name is available in terraform state for resource `aws_rds_cluster.this[0]`. The documentation of this module is missing this detail.

## Breaking Changes
No breaking changes. Only an addition to the description of a module output.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
