### PR TITLE
fix: Add restore_to_point_in_time to ignore_changes

### DIFF
--- a/docs/UPGRADE-8.0.md
+++ b/docs/UPGRADE-8.0.md
@@ -54,7 +54,7 @@ module "cluster_before" {
   version = "~> 7.0"
 
   # Only the affected attributes are shown
-  creat_cluster = true
+  create_cluster = true
 
   master_username        = "admin"
   create_random_password = true
@@ -127,5 +127,5 @@ module "cluster_after" {
 To upgrade to v8.x, you will need to migrate your security group rules to the new `security_group_rules` variable and data structure. There are three potential avenues to accomplish this:
 
 1. Perform Terraform state moves `terraform state mv ...`. This has the downside of requiring manual intervention via the Terraform CLI but is still one possiblity.
-2. Applying the changes as they are which will result in the old security group ruls being removed and the new rules being added. This has the downside of causing a brief interruption in service which may or may not be tolerable; this is left up to users to decided.
+2. Applying the changes as they are which will result in the old security group rules being removed and the new rules being added. This has the downside of causing a brief interruption in service which may or may not be tolerable; this is left up to users to decided.
 3. In addition to option 2, users can create a new, temporary security group that contains all of the same network access (or more) as the current v6.x security group. Before upgrading your cluster, add this security group to the cluster via the `vpc_security_group_ids` argument which "shadows" the same level of network access while upgrading. Once this security group has been added, you can now safely upgrade from v7.x to v8.x without any network disruption. Once the upgrade is complete, you can remove the temporary security group from the cluster and delete.

--- a/main.tf
+++ b/main.tf
@@ -172,6 +172,10 @@ resource "aws_rds_cluster" "this" {
       # See docs here https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_global_cluster#new-global-cluster-from-existing-db-cluster
       global_cluster_identifier,
       snapshot_identifier,
+      # restore_to_point_in_time is a create-only argument used for cloning. Once the cluster
+      # is created, removing the clone inputs should not force replacement of the cluster.
+      # See https://github.com/hashicorp/terraform-provider-aws/issues/17652
+      restore_to_point_in_time,
     ]
   }
 


### PR DESCRIPTION
## Description
Add restore_to_point_in_time to the ignore_changes lifecycle block of the aws_rds_cluster resource.

## Motivation and Context
restore_to_point_in_time is a create-only argument used for cloning clusters via copy-on-write. Once the cluster is created, the clone configuration is no longer relevant. However, when users remove the clone inputs (source_cluster_identifier, restore_type, etc.) after the initial clone — which is the expected workflow — Terraform detects the removal of the restore_to_point_in_time block as a change that forces replacement, planning to destroy and recreate the entire cluster.

This is destructive and unexpected. The fix adds restore_to_point_in_time to ignore_changes, consistent with how snapshot_identifier is already handled (same pattern: create-only, irrelevant after creation).


## Breaking Changes
None. Existing clusters are unaffected. This only prevents unintended force-replacement when clone inputs are removed post-creation.


## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
